### PR TITLE
Update stylesheet for icon hovering

### DIFF
--- a/src/assets/css/default.css
+++ b/src/assets/css/default.css
@@ -186,6 +186,11 @@ li.nav-item a.nav-link i.material-icons {
   width: 20px;
   height: 20px; }
 
+.toolbar-icon:hover svg {
+  fill: #a980d7;
+  width: 20px;
+  height: 20px; }
+
 .post-toolbar-icon svg {
   fill: #5c2d91;
   width: 20px;

--- a/src/assets/css/default.css
+++ b/src/assets/css/default.css
@@ -116,6 +116,9 @@ li.nav-item a.nav-link i.material-icons {
 .app-container {
   padding-top: 76px; }
 
+a {
+  color: #5c2d91; }
+
 .btn-accent {
   background-color: #5c2d91;
   box-shadow: 0px 0px 4px #a2a2a2;
@@ -186,13 +189,18 @@ li.nav-item a.nav-link i.material-icons {
   width: 20px;
   height: 20px; }
 
-.toolbar-icon:hover svg {
+.toolbar-icon:hover div i svg {
   fill: #a980d7;
   width: 20px;
   height: 20px; }
 
 .post-toolbar-icon svg {
   fill: #5c2d91;
+  width: 20px;
+  height: 20px; }
+
+.post-toolbar-icon:hover div i svg {
+  fill: #a980d7;
   width: 20px;
   height: 20px; }
 

--- a/src/assets/scss/_base.scss
+++ b/src/assets/scss/_base.scss
@@ -112,6 +112,14 @@ li.nav-item a.nav-link i.material-icons {
     height: 20px;
 }
 
+.toolbar-icon:hover div i {
+    svg {
+        fill: lighten($theme-accent-color, 30%);
+        width: 20px;
+        height: 20px;
+    }
+}
+
 .post-toolbar-icon svg {
     fill: $theme-accent-color;
     width: 20px;

--- a/src/assets/scss/_base.scss
+++ b/src/assets/scss/_base.scss
@@ -27,6 +27,10 @@ li.nav-item a.nav-link i.material-icons {
     padding-top: 76px;
 }
 
+a {
+    color: $theme-accent-color;
+}
+
 .btn-accent {
     background-color: $theme-accent-color;
     box-shadow: 0px 0px 4px $shadow-color;
@@ -124,6 +128,14 @@ li.nav-item a.nav-link i.material-icons {
     fill: $theme-accent-color;
     width: 20px;
     height: 20px;
+}
+
+.post-toolbar-icon:hover div i {
+    svg {
+        fill: lighten($theme-accent-color, 30%);
+        width: 20px;
+        height: 20px;
+    }
 }
 
 .media-file-icon svg {

--- a/src/components/ComposeWindow/index.js
+++ b/src/components/ComposeWindow/index.js
@@ -170,6 +170,7 @@ class ComposeWindow extends Component {
                     iconName: 'uploadMedia',
                     className: 'toolbar-icon'
                 },
+                className: 'toolbar-icon',
                 onClick: () => this.postMediaForStatus()
             },
             {
@@ -179,6 +180,7 @@ class ComposeWindow extends Component {
                     iconName: this.getVisibilityIcon(),
                     className: 'toolbar-icon'
                 },
+                className: 'toolbar-icon',
                 onClick: () => this.toggleVisibilityDialog()
             },
             {
@@ -188,6 +190,7 @@ class ComposeWindow extends Component {
                     iconName: 'warningApp',
                     className: 'toolbar-icon'
                 },
+                className: 'toolbar-icon',
                 onClick: () => this.toggleSpoilerDialog()
             }
         ];
@@ -202,6 +205,7 @@ class ComposeWindow extends Component {
                     iconName: 'postStatus',
                     className: 'toolbar-icon'
                 },
+                className: 'toolbar-icon',
                 onClick: () => this.postStatus()
             }
         ];

--- a/src/components/Post/PostToolbar.js
+++ b/src/components/Post/PostToolbar.js
@@ -102,6 +102,7 @@ class PostToolbar extends Component {
                                     disabled={false}
                                     checked={false}
                                     onClick={() => this.toggle_favorite()}
+                                    className='post-toolbar-icon'
                                 >
                                     Unfavorite ({this.state.favorites})
                                 </ActionButton>:
@@ -112,6 +113,7 @@ class PostToolbar extends Component {
                                     disabled={false}
                                     checked={false}
                                     onClick={() => this.toggle_favorite()}
+                                    className='post-toolbar-icon'
                                 >
                                     Favorite ({this.state.favorites})
                                 </ActionButton>
@@ -128,6 +130,7 @@ class PostToolbar extends Component {
                                     disabled={false}
                                     checked={false}
                                     onClick={() => this.toggle_boost()}
+                                    className='post-toolbar-icon'
                                 >
                                     Unboost ({this.state.boosts})
                                 </ActionButton>:
@@ -138,6 +141,7 @@ class PostToolbar extends Component {
                                     disabled={false}
                                     checked={false}
                                     onClick={() => this.toggle_boost()}
+                                    className='post-toolbar-icon'
                                 >
                                     Boost ({this.state.boosts})
                                 </ActionButton>
@@ -154,6 +158,7 @@ class PostToolbar extends Component {
                                     disabled={false}
                                     checked={false}
                                     href={this.state.url}
+                                    className='post-toolbar-icon'
                                 >
                                     Link
                                 </ActionButton>:
@@ -164,6 +169,7 @@ class PostToolbar extends Component {
                                         allowDisabledFocus={true}
                                         disabled={false}
                                         checked={false}
+                                        className='post-toolbar-icon'
                                     >
                                         Link
                                     </ActionButton>

--- a/src/components/ReplyWindow/index.js
+++ b/src/components/ReplyWindow/index.js
@@ -74,6 +74,7 @@ class ReplyWindow extends Component {
                     disabled={false}
                     checked={false}
                     onClick={() => this.toggleVisibilityDialog()}
+                    className='post-toolbar-icon'
                 >
                     {this.replyOrThread()} ({this.state.reply_count})
                 </ActionButton>


### PR DESCRIPTION
Following changes have been made:
* All hyperlinks use the theme accent color value
* Icons on the compose window and post toolbar lighten up when hovered