### PR TITLE
Migrate to a reply panel instead of a reply dialog

### DIFF
--- a/src/components/ReplyWindow/index.js
+++ b/src/components/ReplyWindow/index.js
@@ -24,7 +24,7 @@ class ReplyWindow extends Component {
         super(props);
 
         this.state = {
-            hideDialog: true,
+            hideReplyPanel: true,
             to: this.props.status.id,
             reply_count: this.props.status.replies_count,
             author: this.props.status.account.display_name,
@@ -60,13 +60,13 @@ class ReplyWindow extends Component {
 
     openPanel() {
         this.setState({
-            hideDialog: false
+            hideReplyPanel: false
         })
     }
 
     closeReplyPanel() {
         this.setState({
-            hideDialog: true
+            hideReplyPanel: true
         })
     }
 
@@ -86,7 +86,7 @@ class ReplyWindow extends Component {
             media_ids: this.state.media
         });
         this.setState({
-            hideDialog: true
+            hideReplyPanel: true
         })
     }
 
@@ -273,7 +273,7 @@ class ReplyWindow extends Component {
     onSpoilerVisibilityChange(event, checked) {
         this.setState({
             sensitive: !!checked
-        })
+        });
         if (checked === false) {
             this.setState({
                 spoiler_text: ''
@@ -493,7 +493,7 @@ class ReplyWindow extends Component {
     giveDialogBox() {
         return (
             <Panel
-                isOpen={!this.state.hideDialog}
+                isOpen={!this.state.hideReplyPanel}
                 onDismiss={() => this.closeReplyPanel()}
                 headerText={"Reply to " + this.state.author}
                 type={PanelType.medium}

--- a/src/components/ReplyWindow/index.js
+++ b/src/components/ReplyWindow/index.js
@@ -3,12 +3,18 @@ import {
     Dialog,
     DialogFooter,
     DialogType,
+    Panel,
+    PanelType,
+    CommandBar,
     PrimaryButton,
     DefaultButton,
     ActionButton,
     TextField,
-    Link
+    Link, Icon, SelectionMode, DetailsListLayoutMode, DetailsList, ChoiceGroup, Toggle, Callout
 } from 'office-ui-fabric-react';
+import filedialog from 'file-dialog';
+import EmojiPicker from 'emoji-picker-react';
+import 'emoji-picker-react/dist/universal/style.scss';
 
 class ReplyWindow extends Component {
 
@@ -25,7 +31,14 @@ class ReplyWindow extends Component {
             author_id: this.props.status.account.acct,
             original_status: this.getReplyOrMessage(this.props.status),
             reply_contents: '@' + this.props.status.account.acct + ': ',
-            visibility: this.props.status.visibility
+            visibility: this.props.status.visibility,
+            media: [],
+            media_data: [],
+            spoiler_text: '',
+            sensitive: false,
+            hideSpoilerDialog: true,
+            hideEmojiPicker: true,
+            hideVisibilityDialog: true
         };
 
         this.client = this.props.client;
@@ -41,7 +54,19 @@ class ReplyWindow extends Component {
 
     toggleVisibilityDialog() {
         this.setState({
-            hideDialog: !this.state.hideDialog
+            hideVisibilityDialog: !this.state.hideVisibilityDialog
+        })
+    }
+
+    openPanel() {
+        this.setState({
+            hideDialog: false
+        })
+    }
+
+    closeReplyPanel() {
+        this.setState({
+            hideDialog: true
         })
     }
 
@@ -55,7 +80,10 @@ class ReplyWindow extends Component {
         this.client.post('/statuses', {
             status: this.state.reply_contents,
             in_reply_to_id: this.state.to,
-            visibility: this.state.visibility
+            visibility: this.state.visibility,
+            sensitive: this.state.sensitive,
+            spoiler_text: this.state.spoiler_text,
+            media_ids: this.state.media
         });
         this.setState({
             hideDialog: true
@@ -82,38 +110,440 @@ class ReplyWindow extends Component {
         }
     }
 
+    postMediaForStatus() {
+        let _this = this;
+        filedialog({
+            multiple: false,
+            accept: 'image/*, video/*'
+        }).then((images) => {
+            let uploadData = new FormData();
+
+            uploadData.append('file', images[0]);
+
+            _this.client.post('/media', uploadData)
+                .then((resp) => {
+                    console.log('Media uploaded!');
+                    let id = resp.data.id;
+                    let media_id_array = _this.state.media;
+                    let media_data_array = this.state.media_data;
+                    media_id_array.push(id);
+                    media_data_array.push(resp.data);
+                    _this.setState({
+                        media: media_id_array,
+                        media_data: media_data_array
+                    })
+                })
+        })
+    }
+
+    getMediaItemColumns() {
+        return [
+            {
+                key: 'fileIcon',
+                fieldName: 'fileIcon',
+                value: 'File Icon',
+                iconName: 'attachedFile',
+                iconClassName: 'media-file-header-icon',
+                isIconOnly: false,
+                minWidth: 16,
+                maxWidth: 16,
+                isPadded: true
+
+            },
+            {
+                key: 'fileUrl',
+                fieldName: 'fileUrl',
+                iconName: 'linkApp',
+                iconClassName: 'media-file-header-icon',
+                value: 'File URL',
+                minWidth: 24,
+                isPadded: true,
+                isIconOnly: false
+            }
+        ];
+    }
+
+    getMediaItemRows() {
+        let rows = [];
+        if (this.state.media_data.length === 0) {
+            let c = {
+                'fileIcon': <span><Icon iconName='helpApp' className="media-file-icon"/></span>,
+                'fileUrl': 'No media uploaded'
+            };
+            let rows = [];
+            rows.push(c);
+            return rows;
+        } else {
+            for (let i in this.state.media_data) {
+                let c = {
+                    'fileIcon': <span><Icon iconName='attachedFile' className="media-file-icon"/></span>,
+                    'fileUrl': <a href={this.state.media_data[i].url}>{this.state.media_data[i].url}</a>
+                };
+                rows.push(c);
+            }
+        }
+
+        return rows;
+    }
+
+    getVisibilityIcon() {
+        if (this.state.visibility === 'public') {
+            return 'public';
+        } else if (this.state.visibility === 'unlisted') {
+            return 'unlisted';
+        } else if (this.state.visibility === 'private') {
+            return 'private';
+        } else {
+            return 'directMessage';
+        }
+    }
+
+    getSpoilerText() {
+        if (this.state.sensitive) {
+            return (<span className="my-1 ml-2"><Icon iconName = "warningApp"/> <b>Warning: </b>{this.state.spoiler_text} </span>);
+        } else {
+            return (<span/>);
+        }
+    }
+
+    getItems(){
+        return [
+            {
+                key: 'media',
+                name: 'Upload media',
+                iconProps: {
+                    iconName: 'uploadMedia',
+                    className: 'toolbar-icon'
+                },
+                className: 'toolbar-icon',
+                onClick: () => this.postMediaForStatus()
+            },
+            {
+                key: 'visibility',
+                name: 'Change visibility',
+                iconProps: {
+                    iconName: this.getVisibilityIcon(),
+                    className: 'toolbar-icon'
+                },
+                className: 'toolbar-icon',
+                onClick: () => this.toggleVisibilityDialog()
+            },
+            {
+                key: 'emoji',
+                name: 'Add emoji',
+                iconProps: {
+                    iconName: 'emojiPicker',
+                    className: 'toolbar-icon'
+                },
+                className: 'toolbar-icon',
+                id: 'emojiPickerReplyButton',
+                onClick: () => this.toggleEmojiPicker()
+            }
+        ];
+    };
+
+    getOverflowItems() {
+        return [
+            {
+                key: 'spoiler',
+                name: this.setWarningButtonText(),
+                iconProps: {
+                    iconName: 'warningApp',
+                    className: 'toolbar-icon'
+                },
+                className: 'toolbar-icon',
+                onClick: () => this.toggleSpoilerDialog()
+            }
+        ];
+    }
+
+    _onChoiceChanged(event, option) {
+        let _this = this;
+        _this.setState({
+            visibility: option.key
+        });
+    }
+
+    toggleSpoilerDialog() {
+        this.setState({
+            hideSpoilerDialog: !this.state.hideSpoilerDialog
+        })
+    }
+
+    onSpoilerVisibilityChange(event, checked) {
+        this.setState({
+            sensitive: !!checked
+        })
+        if (checked === false) {
+            this.setState({
+                spoiler_text: ''
+            })
+        }
+    }
+
+    onSpoilerTextChange(e) {
+        this.setState({
+            spoiler_text: e.target.value
+        })
+    }
+
+    setVisibilityContentText() {
+        let text = <p>Choose who gets to see your status. By default, new statuses are posted publicly.</p>;
+        let altText = '';
+        if (this.state.visibility === "direct") {
+            altText = <p><b style={{ fontWeight: 700}}>Note: you need to add the recipient/recipients by typing their username/handle to send the message.</b></p>
+        }
+
+        return <span>{text}{altText !== '' ? altText: <span/>}</span>;
+    }
+
+    setWarningButtonText() {
+        if (this.state.sensitive) {
+            return 'Change warning';
+        } else {
+            return 'Add warning';
+        }
+    }
+
+    setWarningHeaderText() {
+        if (this.state.sensitive) {
+            return 'Change or remove your warning';
+        } else {
+            return 'Add a warning';
+        }
+    }
+
+    setWarningContentText() {
+        if (this.state.sensitive) {
+            return 'Change or remove the warning on your post. This may be used to hide a spoiler or provide a warning of the contents of your post that may not be appropriate for all audiences.';
+        } else {
+            return 'Add a content warning to your post. This may be used to hide a spoiler or provide a warning of the contents of your post that may not be appropriate for all audiences.';
+        }
+    }
+
+    toggleEmojiPicker() {
+        this.setState({
+            hideEmojiPicker: !this.state.hideEmojiPicker
+        })
+    }
+
+    addEmojiToStatus(e) {
+        let emojiInsert = String.fromCodePoint("0x" + e);
+        console.log(e);
+        this.setState({
+            reply_contents: this.state.reply_contents + emojiInsert
+        });
+    }
+
+    getTypeOfWarning(event, option) {
+        if (option.key ==='none') {
+            let text = this.state.spoiler_text.replace('NSFW: ', '').replace('Spoiler: ', '');
+            this.setState({
+                spoiler_text: text
+            })
+        } else if (option.key === 'nsfw') {
+            this.setState({
+                spoiler_text: 'NSFW: ' + this.state.spoiler_text.replace('Spoiler: ', '')
+            })
+        } else if (option.key === 'spoiler') {
+            this.setState({
+                spoiler_text: 'Spoiler: ' + this.state.spoiler_text.replace('NSFW: ', '')
+            })
+        }
+    }
+
+    giveVisibilityDialog() {
+        return (
+        <Dialog
+            hidden={this.state.hideVisibilityDialog}
+            onDismiss={() => this.toggleVisibilityDialog()}
+            dialogContentProps={{
+                type: DialogType.largeHeader,
+                title: 'Set your visibility',
+                subText: this.setVisibilityContentText()
+            }}
+            modalProps={{
+                isBlocking: false,
+                containerClassName: 'ms-dialogMainOverride'
+            }}
+            minWidth={500}
+        >
+            <ChoiceGroup
+                options={[
+                    {
+                        key: 'direct',
+                        id: 'message',
+                        text: 'Direct message'
+                    },
+                    {
+                        key: 'private',
+                        id: 'followers',
+                        text: 'Followers only',
+                    },
+                    {
+                        key: 'unlisted',
+                        id: 'unlisted',
+                        text: 'Public (unlisted)',
+                    },
+                    {
+                        key: 'public',
+                        id: 'public',
+                        text: 'Public (fediverse)',
+                        checked: true
+                    }
+                ]}
+                onChange={(event, option) => this._onChoiceChanged(event, option)}
+            />
+            <DialogFooter>
+                <PrimaryButton onClick={() => this.toggleVisibilityDialog()} text="Set" />
+            </DialogFooter>
+        </Dialog>
+        );
+    }
+
+    giveEmojiDialog() {
+        return (<Callout
+            ariaLabelledBy={'callout-label-1'}
+            ariaDescribedBy={'callout-description-1'}
+            role={'alertdialog'}
+            gapSpace={0}
+            hidden={this.state.hideEmojiPicker}
+            target={document.getElementById('emojiPickerReplyButton')}
+        >
+            <EmojiPicker onEmojiClick={(e) => this.addEmojiToStatus(e)} emojiResolution={64}/>
+        </Callout>);
+    }
+
+    giveSpoilerDialog() {
+        return (<Dialog
+            hidden={this.state.hideSpoilerDialog}
+            onDismiss={() => this.toggleSpoilerDialog()}
+            dialogContentProps={{
+                type: DialogType.largeHeader,
+                title: this.setWarningHeaderText(),
+                subText: this.setWarningContentText()
+            }}
+            modalProps={{
+                isBlocking: true,
+                containerClassName: 'ms-dialogMainOverride'
+            }}
+            minWidth={500}
+        >
+            <Toggle
+                defaultChecked={this.state.sensitive}
+                label="Add a warning"
+                onText="On"
+                offText="Off"
+                onChange={(event, checked) => this.onSpoilerVisibilityChange(event, checked)}
+            />
+            <ChoiceGroup
+                disabled={!this.state.sensitive}
+                options={[
+                    {
+                        key: 'none',
+                        id: 'nospecial',
+                        text: "Don't mark specifically",
+                        checked: true
+                    },
+                    {
+                        key: 'nsfw',
+                        id: 'nsfw',
+                        text: "Mark as NSFW"
+                    },
+                    {
+                        key: 'spoiler',
+                        id: 'spoiler',
+                        text: "Mark as a spoiler"
+                    }
+                ]}
+                onChange={(event, option) => this.getTypeOfWarning(event, option)}
+            />
+            <TextField
+                multiline={true}
+                rows={5}
+                resizable={false}
+                label="Warning text"
+                onBlur={(e) => this.onSpoilerTextChange(e)}
+                defaultValue={this.state.spoiler_text}
+            />
+            <DialogFooter>
+                <PrimaryButton onClick={() => this.toggleSpoilerDialog()} text="Save" />
+            </DialogFooter>
+        </Dialog>);
+    }
+
+    getPanelStyles() {
+        return {
+            closeButton: {
+                color: 'transparent',
+                "&:hover": {
+                    color: 'transparent !important'
+                },
+                "&:active": {
+                    color: 'transparent !important'
+                },
+                backgroundImage: 'url(\'/assets/close.svg\')',
+                backgroundPosition: 'center',
+                backgroundRepeat: 'no-repeat',
+                backgroundSize: '50%'
+            }
+        }
+    }
+
     giveDialogBox() {
         return (
-            <Dialog
-                hidden={this.state.hideDialog}
-                onDismiss={() => this.toggleVisibilityDialog()}
-                dialogContentProps={{
-                    type: DialogType.largeHeader,
-                    title: 'Reply to ' + this.state.author,
-                    subText: <div dangerouslySetInnerHTML={{__html: this.state.original_status}}></div>
-                }}
-                modalProps={{
-                    isBlocking: false,
-                    containerClassName: 'ms-dialogMainOverride'
-                }}
-                minWidth={500}
+            <Panel
+                isOpen={!this.state.hideDialog}
+                onDismiss={() => this.closeReplyPanel()}
+                headerText={"Reply to " + this.state.author}
+                type={PanelType.medium}
+                styles={this.getPanelStyles()}
+                onRenderFooterContent={() => {return (
+                            <div>
+                                <PrimaryButton
+                                    onClick={() => this.postReply()}
+                                    style={{marginRight: '8px'}}
+                                    text="Post reply"
+                                />
+                                <DefaultButton
+                                    onClick={() => this.closeReplyPanel()}
+                                    text="Cancel"
+                                />
+                            </div>
+                        )
+                    ;}
+                }
             >
+                <div dangerouslySetInnerHTML={{__html: this.state.original_status}}/>
                 <p>Note: your reply will be sent as a <b>{this.discernVisibilityNoticeKeyword()}.</b></p>
+                <p className="mt-1">{this.getSpoilerText()}</p>
+                <CommandBar
+                    items={this.getItems()}
+                    overflowItems={this.getOverflowItems()}
+                    ariaLabel={'Use left and right arrow keys to navigate between commands'}
+                    overflowButtonProps={{ menuIconProps: {iconName: 'overflowMenu', iconClassName: 'toolbar-icons'}, className: 'toolbar-icon', name: 'More' }}
+                />
                 <TextField
-                    multiline={true}
-                    rows={5}
-                    resizable={false}
-                    maxLength={500}
-                    onBlur={e => this.updateStatus(e)}
-                    placeholder="Type your reply here..."
-                    defaultValue={this.state.reply_contents}
+                multiline={true}
+                rows={5}
+                resizable={false}
+                maxLength={500}
+                onBlur={e => this.updateStatus(e)}
+                placeholder="Type your reply here..."
+                defaultValue={this.state.reply_contents}
+                />
+                <DetailsList
+                    columns={this.getMediaItemColumns()}
+                    items={this.getMediaItemRows()}
+                    selectionMode={SelectionMode.none}
+                    layoutMode={DetailsListLayoutMode.justified}
                 />
 
-                <DialogFooter>
-                    <PrimaryButton onClick={() => this.postReply()} text="Reply" />
-                    <DefaultButton onClick={() => this.toggleVisibilityDialog()} text="Cancel" />
-                </DialogFooter>
-            </Dialog>
+                {this.giveVisibilityDialog()}
+                {this.giveSpoilerDialog()}
+                {this.giveEmojiDialog()}
+
+            </Panel>
         );
     }
 
@@ -125,7 +555,7 @@ class ReplyWindow extends Component {
                 allowDisabledFocus={true}
                 disabled={false}
                 checked={false}
-                onClick={() => this.toggleVisibilityDialog()}
+                onClick={() => this.openPanel()}
                 className='post-toolbar-icon'
             >
                 {this.replyOrThread()} ({this.state.reply_count})
@@ -137,7 +567,7 @@ class ReplyWindow extends Component {
     giveSmallButton() {
         return (
             <span>
-                <Link onClick={() => this.toggleVisibilityDialog()}><b>&nbsp;Reply</b></Link>
+                <Link onClick={() => this.openPanel()}><b>&nbsp;Reply</b></Link>
                 {this.giveDialogBox()}
             </span>
         );

--- a/src/components/ReplyWindow/index.js
+++ b/src/components/ReplyWindow/index.js
@@ -288,7 +288,7 @@ class ReplyWindow extends Component {
     }
 
     setVisibilityContentText() {
-        let text = <p>Choose who gets to see your status. By default, new statuses are posted publicly.</p>;
+        let text = <p>Choose who gets to see your reply.</p>;
         let altText = '';
         if (this.state.visibility === "direct") {
             altText = <p><b style={{ fontWeight: 700}}>Note: you need to add the recipient/recipients by typing their username/handle to send the message.</b></p>


### PR DESCRIPTION
![screenshot_2019-02-10 hyperspace](https://user-images.githubusercontent.com/13445064/52537237-550c6080-2d32-11e9-87ae-a463a680fc64.png)

The reply UI now uses a panel instead of a dialog box. This helps aid in a few things:
* This follows recommendations from Fabric UI's guidelines on dialogs vs. panels, meaning that the reply UI is too complex for a dialog.
* The UI now has more room for things that the compose window usually contains.
* The UI now borrows the same elements from the compose window.

In a later code release, the two systems will probably have core components that are shared to make it easier to work with.