### PR TITLE
Disable Grammarly on status text boxes (fixes #55)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hyperspace",
   "productName": "Hyperspace",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "A fluffy client for Mastodon in React and TypeScript",
   "author": "Marquis Kurt <software@marquiskurt.net>",
   "repository": "https://github.com/alicerunsonfedora/hyperspace.git",

--- a/src/components/ComposeWindow/index.tsx
+++ b/src/components/ComposeWindow/index.tsx
@@ -388,6 +388,7 @@ class ComposeWindow extends Component<IComposeWindowProps, IComposeWindowState> 
                     onChange={e => this.updateStatus(e)}
                     placeholder="What's on your mind?"
                     data-emojiable={true}
+                    data-enable-grammarly={false}
                     defaultValue={this.state.status}
                     onKeyDown = {(event) => this.sendStatusViaKeyboard(event)}
                     title={"Type your status here and click 'Post status' or press Ctrl/⌘ + Enter."}

--- a/src/components/ReplyWindow/index.tsx
+++ b/src/components/ReplyWindow/index.tsx
@@ -589,6 +589,8 @@ class ReplyWindow extends Component<IReplyWindowProps, IReplyWindowState> {
                     rows={5}
                     resizable={false}
                     maxLength={500}
+                    data-emojiable={true}
+                    data-enable-grammarly={false}
                     onChange={e => this.updateStatus(e)}
                     placeholder="Type your reply here..."
                     defaultValue={this.state.reply_contents}


### PR DESCRIPTION
This PR disables Grammarly on the status compose text boxes to prevent clashing.

**Why this change?**
While it is ideal to let Grammarly to do its review magic, it somehow interferes and doesn't let the status properly update its state.