### PR TITLE
Add loader when loading content

### DIFF
--- a/src/components/AccountPanel/index.tsx
+++ b/src/components/AccountPanel/index.tsx
@@ -41,6 +41,7 @@ interface IAccountPanelState {
     header: FormData | any;
     headerPreview: any[];
     media_uploading: boolean;
+    statuses_loading: boolean;
 }
 
 /**
@@ -71,7 +72,8 @@ export class AccountPanel extends Component<IAccountPanelProps, IAccountPanelSta
             avatarPreview: [''],
             header: '',
             headerPreview: [''],
-            media_uploading: false
+            media_uploading: false,
+            statuses_loading: true
         }
 
     }
@@ -238,7 +240,8 @@ export class AccountPanel extends Component<IAccountPanelProps, IAccountPanelSta
         this.client.get('/accounts/' + this.state.account.id + '/statuses', {limit: 150})
             .then((resp: any) => {
                 _this.setState({
-                    account_statuses: resp.data
+                    account_statuses: resp.data,
+                    statuses_loading: false
                 });
             });
     }
@@ -530,7 +533,9 @@ export class AccountPanel extends Component<IAccountPanelProps, IAccountPanelSta
                 </div>
                 <hr/>
                 <div className="my-2">
-                    {this.showRecentStatuses()}
+                    {
+                        this.state.statuses_loading ? <Spinner className = "my-2" size={SpinnerSize.medium} label="Loading your statuses..." ariaLive="assertive" labelPosition="right" />: this.showRecentStatuses()
+                    }
                     <hr/>
                     <div id="end-of-post-roll" className="my-4" style={{textAlign: 'center'}}><Link onClick = {() => this.loadMore()}>Load more</Link></div>
                 </div>

--- a/src/components/NotificationPane/index.tsx
+++ b/src/components/NotificationPane/index.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { ActivityItem, Dialog, DialogType, DialogFooter, Link, PrimaryButton, DefaultButton } from "office-ui-fabric-react";
+import { ActivityItem, Dialog, DialogType, DialogFooter, Link, PrimaryButton, DefaultButton, Spinner, SpinnerSize } from "office-ui-fabric-react";
 import ReplyWindow from '../ReplyWindow';
 import ProfilePanel from '../ProfilePanel';
 import moment from 'moment';
@@ -15,6 +15,7 @@ interface INotificationPaneProps {
 interface INotificationPaneState {
     notifications: [];
     hideDeleteDialog: boolean | undefined;
+    loading: boolean;
 }
 
 /**
@@ -34,7 +35,8 @@ class NotificationPane extends Component<INotificationPaneProps, INotificationPa
 
         this.state = {
             notifications: [],
-            hideDeleteDialog: true
+            hideDeleteDialog: true,
+            loading: true
         }
 
 
@@ -49,7 +51,8 @@ class NotificationPane extends Component<INotificationPaneProps, INotificationPa
             this.client.get('/notifications', {limit: 7})
                 .then((resp: any) => {
                     _this.setState({
-                        notifications: resp.data
+                        notifications: resp.data,
+                        loading: false
                     })
                 });
         });
@@ -236,7 +239,10 @@ class NotificationPane extends Component<INotificationPaneProps, INotificationPa
                         {this.getDeleteDialog()}
                     </div>
                 </div>
-                {this.createActivityList()}
+                {
+                    this.state.loading? <Spinner className = "my-2" size={SpinnerSize.small} label="Loading notifications..." ariaLive="assertive" labelPosition="right" />:
+                    this.createActivityList()
+                }
             </div>
         );
     }

--- a/src/components/Post/PostRoll.tsx
+++ b/src/components/Post/PostRoll.tsx
@@ -182,7 +182,7 @@ class PostRoll extends Component<IPostRollProps, IPostRollState> {
             header = "All clear!";
             body = "It looks like you have no new messages. Interact with some people to get the conversation going!"
         }
-        return (<div>
+        return (<div className="ms-fadeIn100">
             <h3>{header}</h3>
             <p>{body}</p>
             <small>

--- a/src/components/Post/PostRoll.tsx
+++ b/src/components/Post/PostRoll.tsx
@@ -1,6 +1,6 @@
 import Mastodon, {Status, Response} from "megalodon";
 import React, {Component} from 'react';
-import {Link} from 'office-ui-fabric-react';
+import {Link, Spinner, SpinnerSize} from 'office-ui-fabric-react';
 import Post from './index';
 
 
@@ -12,6 +12,7 @@ interface IPostRollProps {
 interface IPostRollState {
     statuses: Array<any>;
     statusCount: Number;
+    loading: boolean;
 }
 
 /**
@@ -27,7 +28,8 @@ class PostRoll extends Component<IPostRollProps, IPostRollState> {
         this.client = props.client;
         this.state = {
             statuses: [],
-            statusCount: 150
+            statusCount: 150,
+            loading: true
         }
     }
 
@@ -43,7 +45,8 @@ class PostRoll extends Component<IPostRollProps, IPostRollState> {
                     .then((resp: any) => {
                         _this.setState({
                             statuses: resp.data,
-                            statusCount: count ++
+                            statusCount: count ++,
+                            loading: false
                         } as unknown as IPostRollState)
                     });
             });
@@ -56,7 +59,8 @@ class PostRoll extends Component<IPostRollProps, IPostRollState> {
                     .then((resp) => {
                         _this.setState({
                             statuses: resp.data,
-                            statusCount: count ++
+                            statusCount: count ++,
+                            loading: false
                         } as unknown as IPostRollState)
                     });
             });
@@ -69,7 +73,8 @@ class PostRoll extends Component<IPostRollProps, IPostRollState> {
                     .then((resp) => {
                         _this.setState({
                             statuses: resp.data,
-                            statusCount: count ++
+                            statusCount: count ++,
+                            loading: false
                         } as unknown as IPostRollState)
                     });
             });
@@ -81,14 +86,19 @@ class PostRoll extends Component<IPostRollProps, IPostRollState> {
                 this.client.get('/conversations', {"limit": _this.state.statusCount, 'local': false})
                     .then((resp) => {
                         let data:any = resp.data;
-                        let messages = [];
-                        for (let i in data) {
-                            messages.push(data[i].last_status);
-                        }
+                        let messages: any = [];
+                        
+                        data.forEach((message: any) => {
+                            if (message.last_status !== null) {
+                                console.log(status);
+                                messages.push(message.last_status);
+                            }
+                        });
 
                         _this.setState({
                             statuses: messages,
-                            statusCount: messages.length
+                            statusCount: messages.length,
+                            loading: false
                         } as unknown as IPostRollState);
                     });
             });
@@ -147,12 +157,15 @@ class PostRoll extends Component<IPostRollProps, IPostRollState> {
         this.client.get(where, params)
             .then((resp) => {
                 let data:any = resp.data;
-                let messages = [];
+                let messages: any = [];
 
                 if (from == "messages") {
-                    for (let i in data) {
-                        messages.push(data[i].last_status);
-                    }
+                    data.forEach((message: any) => {
+                        if (message.last_status !== null) {
+                            console.log(status);
+                            messages.push(message.last_status);
+                        }
+                    });
                 }
 
                 _this.setState({
@@ -183,13 +196,14 @@ class PostRoll extends Component<IPostRollProps, IPostRollState> {
         </div>);
     }
 
-    render() {
+    getPostRoll() {
         let _this = this;
+        console.log("Type: " + this.props.timeline)
         return (
-            <div>
-                {this.state.statuses.length > 0 ? 
+            this.state.statuses.length > 0 ? 
                 <div>
-                    {this.state.statuses.map(function (status: Status) {
+                    {this.state.statuses.map((status: Status) => {
+                        console.log(status);
                             return ( 
                                 <div key={status.id} className="my-3">
                                     <Post client={_this.client} status={status} nolink={false} nothread={false} clickToThread={true}/>
@@ -206,8 +220,15 @@ class PostRoll extends Component<IPostRollProps, IPostRollState> {
                             </div>
                         </div>
 
-                    </div>}
+                    </div>
+        );
+    }
 
+    render() {
+        let _this = this;
+        return (
+            <div>
+                {this.state.loading? <Spinner className = "my-4" size={SpinnerSize.medium} label="Loading timeline..." ariaLive="assertive" labelPosition="right" />: this.getPostRoll()}
             </div>
         );
     }

--- a/src/components/ProfilePanel/index.tsx
+++ b/src/components/ProfilePanel/index.tsx
@@ -1,6 +1,8 @@
 import React, {Component} from 'react';
 import { Panel, PanelType, Link, Persona, PersonaSize, PrimaryButton, DetailsList, DetailsListLayoutMode,
-    SelectionMode } from 'office-ui-fabric-react';
+    SelectionMode, 
+    Spinner,
+    SpinnerSize} from 'office-ui-fabric-react';
 import Post from '../Post';
 import {anchorInBrowser} from "../../utilities/anchorInBrowser";
 import { getTrueInitials } from "../../utilities/getTrueInitials";
@@ -17,6 +19,7 @@ interface IProfilePanelState {
     account_statuses: [];
     following: boolean | undefined;
     openPanel: boolean;
+    loading: boolean;
 }
 
 /**
@@ -38,7 +41,8 @@ class ProfilePanel extends Component<IProfilePanelProps, IProfilePanelState> {
             account: this.props.account,
             account_statuses: [],
             following: false,
-            openPanel: false
+            openPanel: false,
+            loading: true
         }
 
     }
@@ -226,7 +230,8 @@ class ProfilePanel extends Component<IProfilePanelProps, IProfilePanelState> {
         this.client.get('/accounts/' + this.state.account.id + '/statuses', {limit: 150})
             .then((resp: any) => {
                 _this.setState({
-                    account_statuses: resp.data
+                    account_statuses: resp.data,
+                    loading: false
                 });
             });
     }
@@ -333,7 +338,9 @@ class ProfilePanel extends Component<IProfilePanelProps, IProfilePanelState> {
                 </div>
                 <hr/>
                 <div className="my-2">
-                    {this.showRecentStatuses()}
+                    {
+                        this.state.loading? <Spinner className = "my-2" size={SpinnerSize.small} label="Loading statuses..." ariaLive="assertive" labelPosition="right" />: this.showRecentStatuses()
+                    }
                     <hr/>
                     <div id="end-of-post-roll" className="my-4" style={{textAlign: 'center'}}><Link onClick = {() => this.loadMore()}>Load more</Link></div>
                 </div>

--- a/src/components/ThreadPanel/index.js
+++ b/src/components/ThreadPanel/index.js
@@ -3,7 +3,9 @@ import {
     ActionButton,
     Link,
     Panel,
-    PanelType
+    PanelType,
+    Spinner,
+    SpinnerSize
 } from 'office-ui-fabric-react';
 import Post from '../Post';
 import {getDarkMode} from "../../utilities/getDarkMode";
@@ -27,7 +29,8 @@ class ThreadPanel extends Component {
             ancestors: [],
             status: '',
             descendants: [],
-            hideThreadPanel: true
+            hideThreadPanel: true,
+            loading: true
         }
 
         this.client = this.props.client;
@@ -62,7 +65,8 @@ class ThreadPanel extends Component {
             .then( (resp) => {
                     _this.setState({
                         ancestors: resp.data.ancestors,
-                        descendants: resp.data.descendants
+                        descendants: resp.data.descendants,
+                        loading: false
                     })
                 }
             );
@@ -163,11 +167,14 @@ class ThreadPanel extends Component {
                 styles={this.getPanelStyles()}
                 className={getDarkMode()}
             >
-                <div>
-                    {this.displayAncestors()}
-                    {this.displayOriginalStatus()}
-                    {this.displayDescendants()}
-                </div>
+                {
+                    this.state.loading? <Spinner className = "my-2" size={SpinnerSize.medium} label="Loading thread..." ariaLive="assertive" labelPosition="right" />:
+                    <div>
+                        {this.displayAncestors()}
+                        {this.displayOriginalStatus()}
+                        {this.displayDescendants()}
+                    </div>
+                }
             </Panel>
         );
     }


### PR DESCRIPTION
This should prevent confusion of when a timeline/area is actually empty versus when it's loading.

Fixes #60 