### PR TITLE
Fix media links and resolve spoiler ambiguity

### DIFF
--- a/src/assets/css/default.css
+++ b/src/assets/css/default.css
@@ -195,21 +195,39 @@ a {
 .invisible {
   display: none; }
 
+.compose-window-warning {
+  margin-top: 8px;
+  margin-left: 4px;
+  margin-right: 4px;
+  background-color: #ffdc80;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  padding-left: 4px;
+  padding-right: 4px;
+  font-size: 14px;
+  border-radius: 4px;
+  border-color: #ffb900;
+  border-style: solid;
+  border-width: 1px; }
+
 /* Custom Icon SVGs */
+.toolbar-icon {
+  vertical-align: middle; }
+
 .toolbar-icon svg {
   fill: #5c2d91;
-  width: 20px;
-  height: 20px; }
+  width: 18px;
+  height: 18px; }
 
 .toolbar-menu-icon svg {
   fill: #5c2d91;
-  width: 20px;
-  height: 20px; }
+  width: 18px;
+  height: 18px; }
 
 .toolbar-icon:hover div i svg {
   fill: #a980d7;
-  width: 20px;
-  height: 20px; }
+  width: 18px;
+  height: 18px; }
 
 .post-toolbar-icon svg {
   fill: #5c2d91;
@@ -354,6 +372,10 @@ div#profile-table * {
   .dark .navbar-app .ms-Label {
     color: #f4f4f4; }
 
+.dark .compose-window-warning {
+  background-color: #b38200;
+  border-color: #805d00; }
+
 .dark p {
   color: #f4f4f4; }
 
@@ -481,12 +503,12 @@ div#profile-table * {
     color: #f4f4f4; }
     .dark div#compose-window .ms-CommandBar .toolbar-icon svg, .dark div#compose-window .ms-CommandBar * .toolbar-icon svg {
       fill: #a980d7;
-      width: 20px;
-      height: 20px; }
+      width: 18px;
+      height: 18px; }
     .dark div#compose-window .ms-CommandBar .toolbar-icon:hover div i svg, .dark div#compose-window .ms-CommandBar * .toolbar-icon:hover div i svg {
       fill: #ddcdf0;
-      width: 20px;
-      height: 20px; }
+      width: 18px;
+      height: 18px; }
   .dark div#compose-window .ms-DetailsList * {
     background-color: #333; }
     .dark div#compose-window .ms-DetailsList * div[role="row"] {

--- a/src/assets/scss/_base.scss
+++ b/src/assets/scss/_base.scss
@@ -192,24 +192,44 @@ a {
     display: none;
 }
 
+.compose-window-warning {
+    margin-top: 8px;
+    margin-left: 4px;
+    margin-right: 4px;
+    background-color: #ffdc80;
+    padding-top: 8px;
+    padding-bottom: 8px;
+    padding-left: 4px;
+    padding-right: 4px;
+    font-size: 14px;
+    border-radius: 4px;
+    border-color: #ffb900;
+    border-style: solid;
+    border-width: 1px;
+}
+
 /* Custom Icon SVGs */
+.toolbar-icon {
+    vertical-align: middle;
+}
+
 .toolbar-icon svg {
     fill: $theme-accent-color;
-    width: 20px;
-    height: 20px;
+    width: 18px;
+    height: 18px;
 }
 
 .toolbar-menu-icon svg {
     fill: $theme-accent-color;
-    width: 20px;
-    height: 20px;
+    width: 18px;
+    height: 18px;
 }
 
 .toolbar-icon:hover div i {
     svg {
         fill: lighten($theme-accent-color, 30%);
-        width: 20px;
-        height: 20px;
+        width: 18px;
+        height: 18px;
     }
 }
 
@@ -408,6 +428,11 @@ div#profile-table *{
         }
     }
 
+    .compose-window-warning {
+        background-color: #b38200;
+        border-color: #805d00;
+    }
+
     p {
         color: #f4f4f4;
     }
@@ -595,15 +620,15 @@ div#profile-table *{
 
             .toolbar-icon svg {
                 fill: lighten($theme-accent-color, 30%);
-                width: 20px;
-                height: 20px;
+                width: 18px;
+                height: 18px;
             }
             
             .toolbar-icon:hover div i {
                 svg {
                     fill: lighten($theme-accent-color, 50%);
-                    width: 20px;
-                    height: 20px;
+                    width: 18px;
+                    height: 18px;
                 }
             }
         }

--- a/src/components/ComposeWindow/index.tsx
+++ b/src/components/ComposeWindow/index.tsx
@@ -17,6 +17,7 @@ import {
     SpinnerSize
 } from "office-ui-fabric-react";
 import {getDarkMode} from '../../utilities/getDarkMode';
+import {anchorInBrowser} from '../../utilities/anchorInBrowser';
 import filedialog from 'file-dialog';
 import EmojiPicker from 'emoji-picker-react';
 import 'emoji-picker-react/dist/universal/style.scss';
@@ -65,6 +66,10 @@ class ComposeWindow extends Component<IComposeWindowProps, IComposeWindowState> 
         };
 
         this.client = this.props.client;
+    }
+
+    componentDidUpdate() {
+        anchorInBrowser();
     }
 
     updateStatus(e: any) {
@@ -152,13 +157,13 @@ class ComposeWindow extends Component<IComposeWindowProps, IComposeWindowState> 
         } else {
             for (let i in this.state.media_data) {
                 let c = {
-                    'fileIcon': <span><Icon iconName='attachedFile' className="media-file-icon"/></span>,
+                    'fileIcon': <span style={{textAlign: "center"}}><img src={(this.state.media_data[Number(i)] as any).url} style={{ width: "auto", height: 22}}/></span>,
                     'fileUrl': <a href={(this.state.media_data[Number(i)] as any).url}>{(this.state.media_data[Number(i)] as any).url}</a>
                 };
                 rows.push(c);
             }
         }
-
+        
         return rows;
     }
 

--- a/src/components/ComposeWindow/index.tsx
+++ b/src/components/ComposeWindow/index.tsx
@@ -336,26 +336,18 @@ class ComposeWindow extends Component<IComposeWindowProps, IComposeWindowState> 
 
     setWarningButtonText() {
         if (this.state.sensitive) {
-            return 'Change warning';
+            return 'Change/remove warning';
         } else {
-            return 'Add warning';
+            return 'Set warning';
         }
     }
 
     setWarningHeaderText() {
-        if (this.state.sensitive) {
-            return 'Change or remove your warning';
-        } else {
-            return 'Add a warning';
-        }
+        return ('Set a warning');
     }
 
     setWarningContentText() {
-        if (this.state.sensitive) {
-            return 'Change or remove the warning on your post. This may be used to hide a spoiler or provide a warning of the contents of your post that may not be appropriate for all audiences.';
-        } else {
-            return 'Add a content warning to your post. This may be used to hide a spoiler or provide a warning of the contents of your post that may not be appropriate for all audiences.';
-        }
+        return 'Set a content warning to your post. This may be used to hide a spoiler or provide a warning of the contents of your post that may not be appropriate for all audiences.';
     }
 
     toggleEmojiPicker() {
@@ -418,7 +410,11 @@ class ComposeWindow extends Component<IComposeWindowProps, IComposeWindowState> 
                     onKeyDown = {(event) => this.sendStatusViaKeyboard(event)}
                     title={"Type your status here and click 'Post status' or press Ctrl/⌘ + Enter."}
                 />
-                <p className="mt-1">{this.getSpoilerText()}</p>
+                {
+                    this.state.sensitive?
+                    <p className="compose-window-warning">{this.getSpoilerText()}</p>:
+                    <span/>
+                }
                 <DetailsList
                     columns={this.getMediaItemColumns()}
                     items={this.getMediaItemRows()}
@@ -446,7 +442,7 @@ class ComposeWindow extends Component<IComposeWindowProps, IComposeWindowState> 
                 >
                     <Toggle
                         defaultChecked={this.state.sensitive}
-                        label="Add a warning"
+                        label="Set a warning on my post"
                         onText="On"
                         offText="Off"
                         onChange={(event, checked) => this.onSpoilerVisibilityChange(event, checked)}
@@ -454,12 +450,6 @@ class ComposeWindow extends Component<IComposeWindowProps, IComposeWindowState> 
                     <ChoiceGroup
                         disabled={!this.state.sensitive}
                         options={[
-                            {
-                                key: 'none',
-                                id: 'nospecial',
-                                text: "Don't mark specifically",
-                                checked: true
-                            },
                             {
                                 key: 'nsfw',
                                 id: 'nsfw',
@@ -469,9 +459,16 @@ class ComposeWindow extends Component<IComposeWindowProps, IComposeWindowState> 
                                 key: 'spoiler',
                                 id: 'spoiler',
                                 text: "Mark as a spoiler"
+                            },
+                            {
+                                key: 'none',
+                                id: 'nospecial',
+                                text: "Don't mark specifically",
+                                checked: true
                             }
                         ]}
                         onChange={(event, option) => this.getTypeOfWarning(event, option)}
+                        className="mt-2"
                     />
                     <TextField
                         multiline={true}

--- a/src/components/CustomIcons/index.js
+++ b/src/components/CustomIcons/index.js
@@ -46,7 +46,7 @@ registerIcons({
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="none" d="M0 0h24v24H0V0z"/><path d="M12 7V3H2v18h20V7H12zM6 19H4v-2h2v2zm0-4H4v-2h2v2zm0-4H4V9h2v2zm0-4H4V5h2v2zm4 12H8v-2h2v2zm0-4H8v-2h2v2zm0-4H8V9h2v2zm0 -4H8V5h2v2zm10 12h-8v-2h2v-2h-2v-2h2v-2h-2V9h8v10zm-2-8h-2v2h2v-2zm0 4h-2v2h2v-2z"/></svg>
         ),
         'overflowMenu': (
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path opacity=".87" fill="none" d="M24 24H0V0h24v24z"/><path d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6-1.41-1.41z"/></svg>
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"/></svg>
         ),
         'postStatus': (
             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="none" d="M0 0h24v24H0V0z"/><path d="M14.06 9.02l.92.92L5.92 19H5v-.92l9.06-9.06M17.66 3c-.25 0-.51.1-.7.29l-1.83 1.83 3.75 3.75 1.83-1.83c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.2-.2-.45-.29-.71-.29zm-3.6 3.19L3 17.25V21h3.75L17.81 9.94l-3.75-3.75z"/></svg>

--- a/src/components/ReplyWindow/index.tsx
+++ b/src/components/ReplyWindow/index.tsx
@@ -383,26 +383,18 @@ class ReplyWindow extends Component<IReplyWindowProps, IReplyWindowState> {
 
     setWarningButtonText() {
         if (this.state.sensitive) {
-            return 'Change warning';
+            return 'Change/remove warning';
         } else {
-            return 'Add warning';
+            return 'Set warning';
         }
     }
 
     setWarningHeaderText() {
-        if (this.state.sensitive) {
-            return 'Change or remove your warning';
-        } else {
-            return 'Add a warning';
-        }
+        return 'Set a warning';
     }
 
     setWarningContentText() {
-        if (this.state.sensitive) {
-            return 'Change or remove the warning on your post. This may be used to hide a spoiler or provide a warning of the contents of your post that may not be appropriate for all audiences.';
-        } else {
-            return 'Add a content warning to your post. This may be used to hide a spoiler or provide a warning of the contents of your post that may not be appropriate for all audiences.';
-        }
+        return 'Set a content warning to your post. This may be used to hide a spoiler or provide a warning of the contents of your post that may not be appropriate for all audiences.';
     }
 
     toggleEmojiPicker() {
@@ -478,7 +470,7 @@ class ReplyWindow extends Component<IReplyWindowProps, IReplyWindowState> {
         >
             <Toggle
                 defaultChecked={this.state.sensitive}
-                label="Add a warning"
+                label="Set a warning on my post"
                 onText="On"
                 offText="Off"
                 onChange={(event, checked) => this.onSpoilerVisibilityChange(event, checked as boolean)}
@@ -486,12 +478,6 @@ class ReplyWindow extends Component<IReplyWindowProps, IReplyWindowState> {
             <ChoiceGroup
                 disabled={!this.state.sensitive}
                 options={[
-                    {
-                        key: 'none',
-                        id: 'nospecial',
-                        text: "Don't mark specifically",
-                        checked: true
-                    },
                     {
                         key: 'nsfw',
                         id: 'nsfw',
@@ -501,9 +487,16 @@ class ReplyWindow extends Component<IReplyWindowProps, IReplyWindowState> {
                         key: 'spoiler',
                         id: 'spoiler',
                         text: "Mark as a spoiler"
+                    },
+                    {
+                        key: 'none',
+                        id: 'nospecial',
+                        text: "Don't mark specifically",
+                        checked: true
                     }
                 ]}
                 onChange={(event, option) => this.getTypeOfWarning(event, option)}
+                className="mt-2"
             />
             <TextField
                 multiline={true}
@@ -572,7 +565,11 @@ class ReplyWindow extends Component<IReplyWindowProps, IReplyWindowState> {
                 <div id="compose-window" className = "p-3 rounded">
                     <div dangerouslySetInnerHTML={{__html: this.stripOriginalStatus(this.state.original_status)}}/>
                     <p className="mt-2">Note: your reply will be sent as a <b>{this.discernVisibilityNoticeKeyword()}.</b></p>
-                    <p className="mt-1">{this.getSpoilerText()}</p>
+                    {
+                        this.state.sensitive?
+                        <p className="compose-window-warning">{this.getSpoilerText()}</p>:
+                        <span/>
+                    }
                     <CommandBar
                         items={this.getItems()}
                         overflowItems={this.getOverflowItems()}

--- a/src/components/ReplyWindow/index.tsx
+++ b/src/components/ReplyWindow/index.tsx
@@ -18,6 +18,7 @@ import EmojiPicker from 'emoji-picker-react';
 import 'emoji-picker-react/dist/universal/style.scss';
 import Mastodon from 'megalodon';
 import {Visibility} from '../../types/Visibility';
+import {anchorInBrowser} from '../../utilities/anchorInBrowser';
 
 interface IReplyWindowProps {
     client: Mastodon;
@@ -80,6 +81,10 @@ class ReplyWindow extends Component<IReplyWindowProps, IReplyWindowState> {
         };
 
         this.client = this.props.client;
+    }
+
+    componentDidUpdate() {
+        anchorInBrowser();
     }
 
     getReplyOrMessage(status: any) {
@@ -223,8 +228,8 @@ class ReplyWindow extends Component<IReplyWindowProps, IReplyWindowState> {
         } else {
             for (let i in this.state.media_data) {
                 let c = {
-                    'fileIcon': <span><Icon iconName='attachedFile' className="media-file-icon"/></span>,
-                    'fileUrl': <a href={(this.state.media_data[i] as any).url}>{(this.state.media_data[i] as any).url}</a>
+                    'fileIcon': <span style={{textAlign: "center"}}><img src={(this.state.media_data[Number(i)] as any).url} style={{ width: "auto", height: 22}}/></span>,
+                    'fileUrl': <a href={(this.state.media_data[Number(i)] as any).url}>{(this.state.media_data[Number(i)] as any).url}</a>
                 };
                 rows.push(c);
             }


### PR DESCRIPTION
* Links in the compose window/reply window now adhere to `anchorInBrowser()` and show a preview on the side.
* The spoiler text has been re-written to resolve ambiguity.
* The warning on the compose window/reply window looks better, both light and dark.

Fixes #57 and #59