### PR TITLE
Custom emoji support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperspace",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1017,6 +1017,15 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-1.0.9.tgz",
       "integrity": "sha512-WvfJ3LFxBbWjqRGz9n7GJt08RrTHPJDVsIwwoCMROlqF+iDacYiAFjf9oqnq0mXpb2juA2N/qjKP+MKdal3YNQ=="
+    },
+    "@types/emoji-mart": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@types/emoji-mart/-/emoji-mart-2.8.2.tgz",
+      "integrity": "sha512-U3iXg2u/LKjsr5HEq22bHvUhLynKH2x0GeQuRDHXmVtVV+j3nYbf7FNzqr+TdIhbqh7UfIkkCR/7q+WyzU/0dg==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
     },
     "@types/events": {
       "version": "3.0.0",
@@ -5484,6 +5493,12 @@
         "minimalistic-crypto-utils": "^1.0.0"
       }
     },
+    "emoji-mart": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/emoji-mart/-/emoji-mart-2.9.2.tgz",
+      "integrity": "sha512-5S743OpjFb9nBbbx5F4APWgcp2IOjdT7gLLzu2OBh0k44C3ZoCm+wuIN1llOtj5eosUa3lYqrZWtU/ZiaCULrg==",
+      "dev": true
+    },
     "emoji-picker-react": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/emoji-picker-react/-/emoji-picker-react-2.1.1.tgz",
@@ -9815,135 +9830,6 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
-        }
-      }
-    },
-    "jest-css-modules": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jest-css-modules/-/jest-css-modules-1.1.0.tgz",
-      "integrity": "sha1-GTMs92dhjmBS8JAN4l5riFnmW5U=",
-      "dev": true,
-      "requires": {
-        "babel-jest": "^16.0.0"
-      },
-      "dependencies": {
-        "babel-core": {
-          "version": "6.26.3",
-          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
-          "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
-          "dev": true,
-          "requires": {
-            "babel-code-frame": "^6.26.0",
-            "babel-generator": "^6.26.0",
-            "babel-helpers": "^6.24.1",
-            "babel-messages": "^6.23.0",
-            "babel-register": "^6.26.0",
-            "babel-runtime": "^6.26.0",
-            "babel-template": "^6.26.0",
-            "babel-traverse": "^6.26.0",
-            "babel-types": "^6.26.0",
-            "babylon": "^6.18.0",
-            "convert-source-map": "^1.5.1",
-            "debug": "^2.6.9",
-            "json5": "^0.5.1",
-            "lodash": "^4.17.4",
-            "minimatch": "^3.0.4",
-            "path-is-absolute": "^1.0.1",
-            "private": "^0.1.8",
-            "slash": "^1.0.0",
-            "source-map": "^0.5.7"
-          }
-        },
-        "babel-jest": {
-          "version": "16.0.0",
-          "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-16.0.0.tgz",
-          "integrity": "sha1-NIcprqbWJKR3S4qTTQekDdLP1kA=",
-          "dev": true,
-          "requires": {
-            "babel-core": "^6.0.0",
-            "babel-plugin-istanbul": "^2.0.0",
-            "babel-preset-jest": "^16.0.0"
-          }
-        },
-        "babel-plugin-istanbul": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-2.0.3.tgz",
-          "integrity": "sha1-JmswS5EJYH1gdIR0OUZ2mC9mDfQ=",
-          "dev": true,
-          "requires": {
-            "find-up": "^1.1.2",
-            "istanbul-lib-instrument": "^1.1.4",
-            "object-assign": "^4.1.0",
-            "test-exclude": "^2.1.1"
-          }
-        },
-        "babel-plugin-jest-hoist": {
-          "version": "16.0.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-16.0.0.tgz",
-          "integrity": "sha1-tYyj93CYKn58JbVhSy5X6dr8bnY=",
-          "dev": true
-        },
-        "babel-preset-jest": {
-          "version": "16.0.0",
-          "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-16.0.0.tgz",
-          "integrity": "sha1-QXqrwtfZMXD0PCDvHqAUXo9/LbU=",
-          "dev": true,
-          "requires": {
-            "babel-plugin-jest-hoist": "^16.0.0"
-          }
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "json5": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-          "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "test-exclude": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-2.1.3.tgz",
-          "integrity": "sha1-qNiWjh2oMmb5hk8oUsVeIg8GQ0o=",
-          "dev": true,
-          "requires": {
-            "arrify": "^1.0.1",
-            "micromatch": "^2.3.11",
-            "object-assign": "^4.1.0",
-            "read-pkg-up": "^1.0.1",
-            "require-main-filename": "^1.0.1"
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
     "react-dom": "^16.7.0",
     "react-scripts": "2.1.3",
     "typescript": "^3.3.3",
-    "react-awesome-toasts": "^0.0.9"
+    "react-awesome-toasts": "^0.0.9",
+    "emoji-mart": "^2.8.2",
+    "@types/emoji-mart": "^2.8.2"
   },
   "scripts": {
     "compile-sass": "node-sass src/assets/scss/default.scss -o src/assets/css/",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,8 @@ import './assets/css/bootstrap.css';
 import './assets/css/default.css';
 import './components/CustomIcons';
 import RegisterWindow from './components/RegisterWindow';
+import {MastodonEmoji} from './types/Emojis';
+import {CustomEmoji} from 'emoji-mart';
 import { Toast } from './components/Toast';
 import { anchorInBrowser } from './utilities/anchorInBrowser';
 import { getDarkMode } from './utilities/getDarkMode';
@@ -64,6 +66,7 @@ class App extends Component<any, any> {
             };
 
             this.getAccountDetails();
+            this.getServerEmojis();
 
         }
     }
@@ -89,6 +92,31 @@ class App extends Component<any, any> {
                     });
                 });
         }
+    }
+
+    getServerEmojis() {
+        let old_emojis: any[] = JSON.parse(localStorage.getItem("emojis") as string)
+        let emojis: any[] = [];
+        this.client.get('/custom_emojis').then((resp: any) => {
+            resp.data.forEach((emoji: MastodonEmoji) => {
+                let cust = {
+                    name: emoji.shortcode,
+                    emoticons: [''],
+                    short_names: [emoji.shortcode],
+                    imageUrl: emoji.static_url,
+                    keywords: ['mastodon']
+                }
+                emojis.push(cust);
+            });
+            if (old_emojis.length < 0) {
+                localStorage.setItem("emojis", JSON.stringify(emojis));
+            } else {
+                if (old_emojis != emojis) {
+                    localStorage.setItem("emojis", JSON.stringify(emojis));
+                }
+            }
+            
+        });
     }
 
     componentWillMount() {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -108,7 +108,7 @@ class App extends Component<any, any> {
                 }
                 emojis.push(cust);
             });
-            if (old_emojis.length < 0) {
+            if (old_emojis === null) {
                 localStorage.setItem("emojis", JSON.stringify(emojis));
             } else {
                 if (old_emojis != emojis) {

--- a/src/AppContent.tsx
+++ b/src/AppContent.tsx
@@ -14,6 +14,7 @@ class AppContent extends React.Component<any, any> {
     constructor(props: any) {
         super(props);
     }
+    
     render() {
         return (<div>
             <nav>

--- a/src/AppContent.tsx
+++ b/src/AppContent.tsx
@@ -6,6 +6,7 @@ import ProfileContainer, { ProfileUser } from './components/ProfileContainer';
 import Timeline from './components/Timeline';
 import DarkModeToggle from './components/DarkModeToggle';
 import LogoutButton from './components/LogoutButton';
+import { Account } from './types/Account';
 
 /**
  * Base component that renders the app's content if the user is signed in.
@@ -48,7 +49,7 @@ class AppContent extends React.Component<any, any> {
                     <div className="col-sm-12 col-md-4 d-none d-lg-block m-0 p-0 profile-container">
                         <div>
                             {this.props.client ? <div>
-                                {localStorage.getItem('account') ? <ProfileContainer client={this.props.client} who={JSON.parse(localStorage.getItem('account') || "")} /> : <div className="p-4">
+                                {localStorage.getItem('account') ? <ProfileContainer client={this.props.client} who={JSON.parse(localStorage.getItem('account') || "") as Account} /> : <div className="p-4">
                                     <h3>Hang tight!</h3>
                                     <p>Reload Hyperspace for your profile card to update.</p>
                                 </div>}

--- a/src/assets/css/default.css
+++ b/src/assets/css/default.css
@@ -523,6 +523,9 @@ div#profile-table * {
   #boost-card .media {
     padding-left: 8px;
     padding-right: 8px; }
+  #boost-card .boost-persona .emoji {
+    height: 12px;
+    width: 12px; }
 
 .cw-button-nsfw {
   background-color: #ed414f;

--- a/src/assets/css/default.css
+++ b/src/assets/css/default.css
@@ -450,6 +450,41 @@ div#profile-table * {
   margin-right: 2px;
   vertical-align: text-top; }
 
+.carousel-area {
+  border-radius: 4px; }
+
+.post-carousel-item {
+  background-color: #666;
+  width: 100%;
+  height: 350px;
+  text-align: center;
+  position: relative;
+  background-position: initial;
+  background-repeat: initial; }
+  .post-carousel-item .item-bg {
+    /* Add the blur effect */
+    filter: blur(8px);
+    -webkit-filter: blur(8px);
+    /* Full height */
+    height: 100%;
+    /* Center and scale the image nicely */
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: cover; }
+  .post-carousel-item .item-content-container {
+    width: 100%;
+    height: 100%;
+    text-align: center;
+    vertical-align: middle;
+    position: absolute;
+    top: 0;
+    left: 0;
+    padding: 8px; }
+  .post-carousel-item .item-content {
+    max-height: 100%;
+    max-width: 100%;
+    box-shadow: 0px 0px 8px #666; }
+
 .post-author a {
   color: #2b1543; }
 
@@ -489,6 +524,20 @@ div#profile-table * {
     padding-left: 8px;
     padding-right: 8px; }
 
+.cw-button-nsfw {
+  background-color: #ed414f;
+  color: white; }
+
+.cw-button-nsfw:hover {
+  background-color: #f1707b; }
+
+.cw-button-spoiler {
+  color: #333;
+  background-color: #ffc733; }
+
+.cw-button-spoiler:hover {
+  background-color: #ffd566; }
+
 .dark div[id^="post_"], .dark div[id*="post_"] {
   background-color: #333;
   color: #F4F4F4; }
@@ -511,6 +560,20 @@ div#profile-table * {
   border-bottom-color: #111;
   border-left-color: #111;
   border-right-color: #111; }
+
+.dark .cw-button-nsfw {
+  background-color: #ba0e1c;
+  color: white; }
+
+.dark .cw-button-nsfw:hover {
+  background-color: #d10f20; }
+
+.dark .cw-button-spoiler {
+  color: #333;
+  background-color: #cc9400; }
+
+.dark .cw-button-spoiler:hover {
+  background-color: #e6a700; }
 
 /**
     Post Roll and Timeline Styles

--- a/src/assets/css/default.css
+++ b/src/assets/css/default.css
@@ -216,6 +216,12 @@
   margin: 0;
   padding: 0; }
 
+.profile-container-biography {
+  color: #333;
+  font-size: 0.75em;
+  margin-left: 8px;
+  margin-right: 8px; }
+
 .profile-name .emoji {
   width: 18px;
   height: 18px;
@@ -252,6 +258,9 @@
   height: 156px;
   margin: 0;
   padding: 0; }
+
+.dark .profile-container-biography {
+  color: #f4f4f4; }
 
 /**
     Compose Window Styles

--- a/src/assets/css/default.css
+++ b/src/assets/css/default.css
@@ -1,4 +1,11 @@
 /**
+    Hyperspace Stylesheet
+    (C) 2019 Marquis Kurt. Licensed under Lesser GNU GPL v3.
+
+    This stylesheet works best with Bootstrap 4 and the Fabric UI stylesheets.
+*/
+/* Imported Styles from Components */
+/**
   Font Declarations
 */
 @font-face {
@@ -209,6 +216,13 @@
 
 .profile-container-bio {
   text-align: center; }
+
+.avatar {
+  background-size: contain;
+  background-position: center;
+  background-repeat: no-repeat;
+  width: 64px;
+  height: 64px; }
 
 .dark div#profile-container {
   background-color: #333;
@@ -498,6 +512,11 @@ li.nav-item a.nav-link i.material-icons {
 a {
   color: #5c2d91; }
 
+.btn-accent {
+  background-color: #5c2d91;
+  box-shadow: 0px 0px 4px #a2a2a2;
+  color: white; }
+
 .dark .clickable-link:not([href]):not([tabindex]),
 .dark .clickable-link:not([href]):not([tabindex]):focus,
 .dark .clickable-link:not([href]):not([tabindex]):hover,
@@ -519,15 +538,18 @@ a {
 .dark a:active {
   color: #ddcdf0; }
 
-* {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif !important; }
+/**
+    Notification Pane Styles
+*/
+.dark div#notification-pane {
+  background-color: #333;
+  color: #f4f4f4; }
+  .dark div#notification-pane .ms-ActivityItem-commentText {
+    color: #f4f4f4; }
 
-.hidden-scroll body ::-webkit-scrollbar {
-  display: none; }
-
-.hidden-scroll .app-container {
-  padding-top: 100px; }
-
+/**
+    Container Styles
+*/
 .app-container {
   padding-top: 76px; }
 
@@ -541,28 +563,28 @@ div#root .dark {
 .marked-area {
   background-color: white; }
 
-.btn-accent {
-  background-color: #5c2d91;
-  box-shadow: 0px 0px 4px #a2a2a2;
-  color: white; }
+.dark .marked-area {
+  background-color: #333;
+  color: #f4f4f4; }
 
-.avatar {
-  background-size: contain;
-  background-position: center;
-  background-repeat: no-repeat;
-  width: 64px;
-  height: 64px; }
+/**
+    Utility Classes
+*/
+.hidden-scroll body ::-webkit-scrollbar {
+  display: none; }
+
+.hidden-scroll .app-container {
+  padding-top: 100px; }
 
 .invisible {
   display: none; }
 
-/* DARK MODE */
+/* Regular Styles */
+* {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif !important; }
+
 .dark p {
   color: #f4f4f4; }
 
 .dark .toggle i svg {
   fill: white; }
-
-.dark .marked-area {
-  background-color: #333;
-  color: #f4f4f4; }

--- a/src/assets/css/default.css
+++ b/src/assets/css/default.css
@@ -483,7 +483,7 @@ div#profile-table * {
   .post-carousel-item .item-content {
     max-height: 100%;
     max-width: 100%;
-    box-shadow: 0px 0px 8px #666; }
+    box-shadow: 0 0 8px #666; }
 
 .post-author a {
   color: #2b1543; }
@@ -541,12 +541,15 @@ div#profile-table * {
 .cw-button-spoiler:hover {
   background-color: #ffd566; }
 
-.dark div[id^="post_"], .dark div[id*="post_"] {
+.dark div[id^="post_"],
+.dark div[id*="post_"] {
   background-color: #333;
   color: #F4F4F4; }
-  .dark div[id^="post_"] .ms-Persona-primaryText, .dark div[id*="post_"] .ms-Persona-primaryText {
+  .dark div[id^="post_"] .ms-Persona-primaryText,
+  .dark div[id*="post_"] .ms-Persona-primaryText {
     color: #f4f4f4; }
-  .dark div[id^="post_"] small.text-muted, .dark div[id*="post_"] small.text-muted {
+  .dark div[id^="post_"] small.text-muted,
+  .dark div[id*="post_"] small.text-muted {
     color: #a6a6a6 !important; }
 
 .dark ul#post-toolbar * {

--- a/src/assets/css/default.css
+++ b/src/assets/css/default.css
@@ -422,6 +422,13 @@ div#profile-table * {
   color: #7539b8;
   font-weight: bold; }
 
+.post-content .emoji {
+  width: 1rem;
+  height: 1rem;
+  margin-left: 2px;
+  margin-right: 2px;
+  vertical-align: text-top; }
+
 .post-author a {
   color: #2b1543; }
 

--- a/src/assets/css/default.css
+++ b/src/assets/css/default.css
@@ -461,6 +461,25 @@ div#profile-table * {
   width: 20px;
   height: 20px; }
 
+#boost-card {
+  border-color: #eaeaea;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 2px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  margin-right: 8px;
+  margin-left: 8px; }
+  #boost-card .post-content {
+    padding-left: 12px;
+    padding-right: 12px;
+    padding-top: 4px;
+    color: #666;
+    font-size: 0.85em; }
+  #boost-card .media {
+    padding-left: 8px;
+    padding-right: 8px; }
+
 .dark div[id^="post_"], .dark div[id*="post_"] {
   background-color: #333;
   color: #F4F4F4; }
@@ -476,20 +495,13 @@ div#profile-table * {
   .dark ul#post-toolbar * .post-toolbar-icon:hover div i svg {
     fill: #ddcdf0; }
 
-.dark div#boost-card .ms-DocumentCardDetails {
+.dark #boost-card {
   background-color: #212121;
-  color: #f4f4f4; }
-
-.dark div#boost-card div {
+  color: #f4f4f4;
   border-top-color: #111;
   border-bottom-color: #111;
   border-left-color: #111;
   border-right-color: #111; }
-  .dark div#boost-card div :hover {
-    border-top-color: #333;
-    border-bottom-color: #333;
-    border-left-color: #333;
-    border-right-color: #333; }
 
 /**
     Post Roll and Timeline Styles

--- a/src/assets/css/default.css
+++ b/src/assets/css/default.css
@@ -67,7 +67,9 @@
 
 .navbar-brand {
   font-family: "Manrope", -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif !important;
-  letter-spacing: 2px; }
+  letter-spacing: 2px;
+  padding-top: 0.2110rem;
+  padding-bottom: 0.2110rem; }
 
 .mac-title-bar {
   text-align: center;
@@ -213,6 +215,16 @@
   height: 156px;
   margin: 0;
   padding: 0; }
+
+.profile-name .emoji {
+  width: 18px;
+  height: 18px;
+  vertical-align: text-top; }
+
+.profile-persona .emoji {
+  width: 21px;
+  height: 21px;
+  vertical-align: text-top; }
 
 .profile-container-bio {
   text-align: center; }

--- a/src/assets/scss/_posts.scss
+++ b/src/assets/scss/_posts.scss
@@ -36,7 +36,7 @@
         -webkit-filter: blur(8px);
 
         /* Full height */
-        height: 100%; 
+        height: 100%;
 
         /* Center and scale the image nicely */
         background-position: center;
@@ -58,7 +58,7 @@
     .item-content {
         max-height: 100%;
         max-width: 100%;
-        box-shadow: 0px 0px 8px #666;
+        box-shadow: 0 0 8px #666;
     }
 }
 
@@ -138,7 +138,9 @@
 
 
 .dark {
-    div[id^="post_"], div[id*="post_"] {
+
+    div[id^="post_"],
+    div[id*="post_"] {
         background-color: #333;
         color: #F4F4F4;
 
@@ -157,7 +159,7 @@
         .post-toolbar-icon svg {
             fill: lighten($theme-accent-color, 30%);
         }
-        
+
         .post-toolbar-icon:hover div i {
             svg {
                 fill: lighten($theme-accent-color, 50%);
@@ -179,16 +181,16 @@
         background-color: #ba0e1c;
         color: white;
     }
-    
+
     .cw-button-nsfw:hover {
         background-color: #d10f20;
     }
-    
+
     .cw-button-spoiler {
         color: #333;
         background-color: #cc9400;
     }
-    
+
     .cw-button-spoiler:hover {
         background-color: #e6a700;
     }

--- a/src/assets/scss/_posts.scss
+++ b/src/assets/scss/_posts.scss
@@ -111,6 +111,11 @@
         padding-left: 8px;
         padding-right: 8px;
     }
+
+    .boost-persona .emoji {
+        height: 12px;
+        width: 12px;
+    }
 }
 
 .cw-button-nsfw {

--- a/src/assets/scss/_posts.scss
+++ b/src/assets/scss/_posts.scss
@@ -17,6 +17,51 @@
     }
 }
 
+.carousel-area {
+    border-radius: 4px;
+}
+
+.post-carousel-item {
+    background-color: #666;
+    width: 100%;
+    height: 350px;
+    text-align: center;
+    position: relative;
+    background-position: initial;
+    background-repeat: initial;
+
+    .item-bg {
+        /* Add the blur effect */
+        filter: blur(8px);
+        -webkit-filter: blur(8px);
+
+        /* Full height */
+        height: 100%; 
+
+        /* Center and scale the image nicely */
+        background-position: center;
+        background-repeat: no-repeat;
+        background-size: cover;
+    }
+
+    .item-content-container {
+        width: 100%;
+        height: 100%;
+        text-align: center;
+        vertical-align: middle;
+        position: absolute;
+        top: 0;
+        left: 0;
+        padding: 8px;
+    }
+
+    .item-content {
+        max-height: 100%;
+        max-width: 100%;
+        box-shadow: 0px 0px 8px #666;
+    }
+}
+
 .post-author a {
     color: darken($theme-accent-color, 20%);
 }
@@ -68,6 +113,24 @@
     }
 }
 
+.cw-button-nsfw {
+    background-color: #ed414f;
+    color: white;
+}
+
+.cw-button-nsfw:hover {
+    background-color: #f1707b;
+}
+
+.cw-button-spoiler {
+    color: #333;
+    background-color: #ffc733;
+}
+
+.cw-button-spoiler:hover {
+    background-color: #ffd566;
+}
+
 
 .dark {
     div[id^="post_"], div[id*="post_"] {
@@ -105,5 +168,23 @@
         border-bottom-color: #111;
         border-left-color: #111;
         border-right-color: #111;
+    }
+
+    .cw-button-nsfw {
+        background-color: #ba0e1c;
+        color: white;
+    }
+    
+    .cw-button-nsfw:hover {
+        background-color: #d10f20;
+    }
+    
+    .cw-button-spoiler {
+        color: #333;
+        background-color: #cc9400;
+    }
+    
+    .cw-button-spoiler:hover {
+        background-color: #e6a700;
     }
 }

--- a/src/assets/scss/_posts.scss
+++ b/src/assets/scss/_posts.scss
@@ -44,6 +44,30 @@
     }
 }
 
+#boost-card {
+    border-color: #eaeaea;
+    border-width: 1px;
+    border-style: solid;
+    border-radius: 2px;
+    padding-top: 4px;
+    padding-bottom: 4px;
+    margin-right: 8px;
+    margin-left: 8px;
+
+    .post-content {
+        padding-left: 12px;
+        padding-right: 12px;
+        padding-top: 4px;
+        color: #666;
+        font-size: 0.85em;
+    }
+
+    .media {
+        padding-left: 8px;
+        padding-right: 8px;
+    }
+}
+
 
 .dark {
     div[id^="post_"], div[id*="post_"] {
@@ -73,24 +97,13 @@
         }
     }
 
-    div#boost-card {
-        .ms-DocumentCardDetails {
-            background-color: #212121;
-            color: #f4f4f4;
-        }
-        div {
-            border-top-color: #111;
-            border-bottom-color: #111;
-            border-left-color: #111;
-            border-right-color: #111;
+    #boost-card {
+        background-color: #212121;
+        color: #f4f4f4;
 
-            :hover {
-                border-top-color: #333;
-                border-bottom-color: #333;
-                border-left-color: #333;
-                border-right-color: #333;
-            }
-        }
-        
+        border-top-color: #111;
+        border-bottom-color: #111;
+        border-left-color: #111;
+        border-right-color: #111;
     }
 }

--- a/src/assets/scss/_posts.scss
+++ b/src/assets/scss/_posts.scss
@@ -2,9 +2,19 @@
     Post Card Styles
 */
 
-.post-content a {
-    color: lighten($theme-accent-color, 10%);
-    font-weight: bold;
+.post-content {
+    a {
+        color: lighten($theme-accent-color, 10%);
+        font-weight: bold;
+    }
+
+    .emoji {
+        width: 1rem;
+        height: 1rem;
+        margin-left: 2px;
+        margin-right: 2px;
+        vertical-align: text-top;
+    }
 }
 
 .post-author a {

--- a/src/assets/scss/_profile-container.scss
+++ b/src/assets/scss/_profile-container.scss
@@ -32,6 +32,22 @@
     padding: 0;
 }
 
+.profile-name {
+    .emoji {
+        width: 18px;
+        height: 18px;
+        vertical-align: text-top;
+    }
+}
+
+.profile-persona {
+    .emoji {
+        width: 21px;
+        height: 21px;
+        vertical-align: text-top;
+    }
+}
+
 .profile-container-bio {
     text-align: center;
 }

--- a/src/assets/scss/_profile-container.scss
+++ b/src/assets/scss/_profile-container.scss
@@ -32,6 +32,14 @@
     padding: 0;
 }
 
+
+.profile-container-biography {
+    color: #333;
+    font-size: 0.75em;
+    margin-left: 8px;
+    margin-right: 8px;
+}
+
 .profile-name {
     .emoji {
         width: 18px;
@@ -85,5 +93,9 @@
         height: 156px;
         margin: 0;
         padding: 0;
+    }
+
+    .profile-container-biography {
+        color: #f4f4f4;
     }
 }

--- a/src/components/AccountPanel/index.tsx
+++ b/src/components/AccountPanel/index.tsx
@@ -1,13 +1,13 @@
 import React, {Component} from 'react';
-import { Panel, 
-    PanelType, 
-    Link, 
-    Persona, 
-    PersonaSize, 
-    PrimaryButton, 
-    DetailsList, 
+import { Panel,
+    PanelType,
+    Link,
+    Persona,
+    PersonaSize,
+    PrimaryButton,
+    DetailsList,
     DetailsListLayoutMode,
-    SelectionMode, 
+    SelectionMode,
     DefaultButton,
     Dialog,
     DialogFooter,
@@ -49,7 +49,7 @@ interface IAccountPanelState {
  * A panel that display profile information of the signed in user.
  * This is similar to ProfilePanel, but includes options that pertain
  * to the user specifically (edit bio, change images).
- * 
+ *
  * @param client The client used to get and post information with.
  * @param account The account to get information about.
  */
@@ -160,7 +160,7 @@ export class AccountPanel extends Component<IAccountPanelProps, IAccountPanelSta
                 isPadded: true
             }];
         let rows = [];
-        
+
         for (let item in account.fields) {
             let value = account.fields[item].value.replace("class=\"invisible\"", '');
             rows.push({'key': account.fields[item].name, 'value': <p dangerouslySetInnerHTML={{__html: value}}/>})
@@ -179,7 +179,7 @@ export class AccountPanel extends Component<IAccountPanelProps, IAccountPanelSta
                 </div>
             );
         }
-        
+
     }
 
     checkDisplayName(account: any) {
@@ -254,7 +254,7 @@ export class AccountPanel extends Component<IAccountPanelProps, IAccountPanelSta
         this.client.get('/accounts/' + this.state.account.id + '/statuses', {"max_id": last_status})
             .then( (resp: any) => {
                 let data = resp.data;
-                
+
                 _this.setState({
                     account_statuses: (_this.state.account_statuses.concat(resp.data) as any)
                 })
@@ -317,7 +317,7 @@ export class AccountPanel extends Component<IAccountPanelProps, IAccountPanelSta
                 </DialogFooter>
             </Dialog>
         );
-        
+
     }
 
     updateBioText(e: any) {
@@ -375,16 +375,16 @@ export class AccountPanel extends Component<IAccountPanelProps, IAccountPanelSta
                 >
                     <div className = "mx-auto">
                         {
-                            this.state.avatar !== '' ? 
-                                this.renderNewAvatar(): 
-                                <img 
+                            this.state.avatar !== '' ?
+                                this.renderNewAvatar():
+                                <img
                                     src={this.props.account.avatar_static}
                                     className="rounded-circle shadow-sm"
                                     style={{width: '50%'}}
                                     onClick={() => this.uploadImage("avatar")}
                                 />
                         }
-                        
+
                     </div>
                 </div>
                 {this.state.media_uploading ? <Spinner className = "my-3" size={SpinnerSize.medium} label="Updating profile..." ariaLive="assertive" labelPosition="right" />: <span/>}

--- a/src/components/AccountPanel/index.tsx
+++ b/src/components/AccountPanel/index.tsx
@@ -21,8 +21,9 @@ import {anchorInBrowser} from "../../utilities/anchorInBrowser";
 import { getTrueInitials } from "../../utilities/getTrueInitials";
 import {getDarkMode} from "../../utilities/getDarkMode";
 import {emojifyHTML} from "../../utilities/emojify";
-import Mastodon, { Status } from 'megalodon';
+import Mastodon from 'megalodon';
 import filedialog from 'file-dialog';
+import { Status } from '../../types/Status';
 
 interface IAccountPanelProps {
     client: Mastodon;
@@ -32,7 +33,7 @@ interface IAccountPanelProps {
 
 interface IAccountPanelState {
     account: any;
-    account_statuses: [];
+    account_statuses: Status[];
     openPanel: boolean;
     openBioDialog: boolean;
     openImageDialog: boolean;
@@ -253,10 +254,10 @@ export class AccountPanel extends Component<IAccountPanelProps, IAccountPanelSta
 
         this.client.get('/accounts/' + this.state.account.id + '/statuses', {"max_id": last_status})
             .then( (resp: any) => {
-                let data = resp.data;
+                let data: [Status] = resp.data;
 
                 _this.setState({
-                    account_statuses: (_this.state.account_statuses.concat(resp.data) as any)
+                    account_statuses: (_this.state.account_statuses.concat(data))
                 })
 
             })

--- a/src/components/AccountPanel/index.tsx
+++ b/src/components/AccountPanel/index.tsx
@@ -20,6 +20,7 @@ import Post from '../Post';
 import {anchorInBrowser} from "../../utilities/anchorInBrowser";
 import { getTrueInitials } from "../../utilities/getTrueInitials";
 import {getDarkMode} from "../../utilities/getDarkMode";
+import {emojifyHTML} from "../../utilities/emojify";
 import Mastodon, { Status } from 'megalodon';
 import filedialog from 'file-dialog';
 
@@ -126,9 +127,12 @@ export class AccountPanel extends Component<IAccountPanelProps, IAccountPanelSta
         } else {
             return (
                 <span>
-                    <Link onClick={() => this.toggleProfilePanel()} style={{
+                    <Link
+                    className = "profile-name"
+                    dangerouslySetInnerHTML={{__html: this.checkDisplayName(this.state.account)}}
+                    onClick={() => this.toggleProfilePanel()} style={{
                         fontWeight: 'bold'
-                    }}>{this.checkDisplayName(this.state.account)}</Link>
+                    }}></Link>
                 </span>
             );
         }
@@ -179,11 +183,7 @@ export class AccountPanel extends Component<IAccountPanelProps, IAccountPanelSta
     }
 
     checkDisplayName(account: any) {
-        if (account.display_name === "") {
-            return account.username;
-        } else {
-            return account.display_name;
-        }
+        return emojifyHTML(account.display_name) || account.username;
     }
 
     getProfileMetadata(account: any) {
@@ -198,7 +198,7 @@ export class AccountPanel extends Component<IAccountPanelProps, IAccountPanelSta
                         {
                             imageUrl: this.state.account.avatar,
                             imageInitials: getTrueInitials(this.state.account.display_name),
-                            text: this.checkDisplayName(this.state.account) + " (you)",
+                            text: <span dangerouslySetInnerHTML={{__html: this.checkDisplayName(this.state.account)}}></span> as unknown as string,
                             title: 'Despite everything, it\'s still you.',
                             secondaryText: '@' + this.state.account.username,
                             tertiaryText: this.getProfileMetadata(this.state.account)
@@ -224,6 +224,7 @@ export class AccountPanel extends Component<IAccountPanelProps, IAccountPanelSta
                             }
                         }
                     }
+                    className = "profile-persona"
                 />
                 <div className="mt-4">
                     <PrimaryButton text="Edit bio" style={{marginRight: 8}} onClick={() => this.toggleBioDialog()}/>

--- a/src/components/AccountPanel/index.tsx
+++ b/src/components/AccountPanel/index.tsx
@@ -24,15 +24,16 @@ import {emojifyHTML} from "../../utilities/emojify";
 import Mastodon from 'megalodon';
 import filedialog from 'file-dialog';
 import { Status } from '../../types/Status';
+import { Account } from '../../types/Account';
 
 interface IAccountPanelProps {
     client: Mastodon;
-    account: any;
+    account: Account;
     button?: boolean;
 }
 
 interface IAccountPanelState {
-    account: any;
+    account: Account;
     account_statuses: Status[];
     openPanel: boolean;
     openBioDialog: boolean;
@@ -69,7 +70,7 @@ export class AccountPanel extends Component<IAccountPanelProps, IAccountPanelSta
             openPanel: false,
             openBioDialog: false,
             openImageDialog: false,
-            bioText: this.props.account.source.note,
+            bioText: this.props.account.note,
             avatar: '',
             avatarPreview: [''],
             header: '',
@@ -336,7 +337,7 @@ export class AccountPanel extends Component<IAccountPanelProps, IAccountPanelSta
                 localStorage.setItem('account', JSON.stringify(acct.data));
                 this.setState({
                     account: acct.data,
-                    bioText: acct.data.source.note,
+                    bioText: acct.data.note,
                     openBioDialog: false
                 })
             });

--- a/src/components/AccountPanel/index.tsx
+++ b/src/components/AccountPanel/index.tsx
@@ -185,7 +185,7 @@ export class AccountPanel extends Component<IAccountPanelProps, IAccountPanelSta
     }
 
     checkDisplayName(account: any) {
-        return emojifyHTML(account.display_name) || account.username;
+        return emojifyHTML(account.display_name, account.emojis) || account.username;
     }
 
     getProfileMetadata(account: any) {

--- a/src/components/ComposeWindow/index.tsx
+++ b/src/components/ComposeWindow/index.tsx
@@ -19,10 +19,10 @@ import {
 import {getDarkMode} from '../../utilities/getDarkMode';
 import {anchorInBrowser} from '../../utilities/anchorInBrowser';
 import filedialog from 'file-dialog';
-import EmojiPicker from 'emoji-picker-react';
-import 'emoji-picker-react/dist/universal/style.scss';
 import Mastodon, {Status} from 'megalodon';
 import {Visibility} from '../../types/Visibility';
+import EmojiPicker from '../EmojiPicker';
+
 
 interface IComposeWindowProps {
     client: Mastodon;
@@ -357,11 +357,15 @@ class ComposeWindow extends Component<IComposeWindowProps, IComposeWindowState> 
     }
 
     addEmojiToStatus(e: any) {
-        let emojiInsert = String.fromCodePoint(("0x" + e) as unknown as number);
-        console.log(e);
-        this.setState({
-            status: this.state.status + emojiInsert
-        });
+        if (e.custom) {
+            this.setState({
+                status: this.state.status + e.colons
+            })
+        } else {
+            this.setState({
+                status: this.state.status + e.native
+            })
+        }
     }
 
     getTypeOfWarning(event: any, option: any) {
@@ -493,11 +497,7 @@ class ComposeWindow extends Component<IComposeWindowProps, IComposeWindowState> 
                     onDismiss={() => this.toggleEmojiPicker()}
                     target={document.getElementById('emojiPickerButton')}
                 >
-                    <EmojiPicker 
-                        onEmojiClick={(e: Event) => this.addEmojiToStatus(e)} 
-                        assetPath="./images/emoji"
-                        emojiResolution={128}
-                    />
+                    <EmojiPicker client={this.client} onGetEmoji={(emoji: any) => {this.addEmojiToStatus(emoji)}}/>
                 </Callout>
             </div>
         );

--- a/src/components/ComposeWindow/index.tsx
+++ b/src/components/ComposeWindow/index.tsx
@@ -43,7 +43,7 @@ interface IComposeWindowState {
 /**
  * Window for creating statuses. Generally used for composing new statuses
  * rather than replies.
- * 
+ *
  * @param client The Mastodon client to perform posting actions with
  */
 class ComposeWindow extends Component<IComposeWindowProps, IComposeWindowState> {
@@ -163,7 +163,7 @@ class ComposeWindow extends Component<IComposeWindowProps, IComposeWindowState> 
                 rows.push(c);
             }
         }
-        
+
         return rows;
     }
 

--- a/src/components/EmojiPicker/index.tsx
+++ b/src/components/EmojiPicker/index.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { Component } from 'react';
+import {Picker, PickerProps, CustomEmoji} from 'emoji-mart';
+import 'emoji-mart/css/emoji-mart.css';
+import Mastodon from 'megalodon';
+
+interface EmojiPickerProps extends PickerProps {
+    client: Mastodon;
+    onGetEmoji: any;
+}
+
+class EmojiPicker extends React.Component<EmojiPickerProps, any> {
+
+    retrieveFromLocalStorage() {
+        return JSON.parse(localStorage.getItem("emojis") as string);
+    }
+
+
+
+    render() { 
+        return ( 
+            <Picker custom={this.retrieveFromLocalStorage()} emoji='' title='' onClick={this.props.onGetEmoji}/>
+         );
+    }
+}
+ 
+export default EmojiPicker;

--- a/src/components/EmojiPicker/index.tsx
+++ b/src/components/EmojiPicker/index.tsx
@@ -17,8 +17,8 @@ class EmojiPicker extends React.Component<EmojiPickerProps, any> {
 
 
 
-    render() { 
-        return ( 
+    render() {
+        return (
             <Picker custom={this.retrieveFromLocalStorage()} emoji='' title='' onClick={this.props.onGetEmoji}/>
          );
     }

--- a/src/components/EmojiPicker/index.tsx
+++ b/src/components/EmojiPicker/index.tsx
@@ -19,7 +19,7 @@ class EmojiPicker extends React.Component<EmojiPickerProps, any> {
 
     render() {
         return (
-            <Picker custom={this.retrieveFromLocalStorage()} emoji='' title='' onClick={this.props.onGetEmoji}/>
+            <Picker custom={this.retrieveFromLocalStorage()} emoji='point_up' title='Pick an emoji' onClick={this.props.onGetEmoji}/>
          );
     }
 }

--- a/src/components/Post/BoostCard.tsx
+++ b/src/components/Post/BoostCard.tsx
@@ -39,12 +39,6 @@ class BoostCard extends Component<IBoostCardProps, IBoostCardState> {
         }
     }
 
-    stripElementsFromContent(content: string) {
-        let temporaryDiv = document.createElement("div");
-        temporaryDiv.innerHTML = content;
-        return temporaryDiv.textContent || temporaryDiv.innerText || "";
-    }
-
     openChildThreadPanel() {
         if (this.threadRef.current.getHiddenPanelState())
             this.threadRef.current.openThreadPanel()
@@ -104,7 +98,7 @@ class BoostCard extends Component<IBoostCardProps, IBoostCardState> {
                         <div className = "media">{this.prepareMedia(post.media_attachments)}</div>:<span/>
                     }
                     <DocumentCardActivity
-                        activity={"Originally posted on " + moment(post.created_at).format("MMM Do, YYYY: h:mm A")}
+                        activity={"Posted on " + moment(post.created_at).format("MMM Do, YYYY: h:mm A")}
                         people={[{ name: <ProfilePanel account={post.account} client={this.client}/> as unknown as string, profileImageSrc: post.account.avatar, initials:getTrueInitials(post.account.display_name)}]}
                     />
                 </div>

--- a/src/components/Post/BoostCard.tsx
+++ b/src/components/Post/BoostCard.tsx
@@ -76,7 +76,7 @@ class BoostCard extends Component<IBoostCardProps, IBoostCardState> {
                 {
                     (media[0].type === "image") ?
                         <img src={media[0].url} className = "shadow-sm rounded" alt={media[0].description} style = {{ width: '100%' }}/>:
-                        <video src={media[0].url} autoPlay={false} controls={true} className = "shadow-sm rounded" style = {{ width: '100%' }}/>
+                        <video src={media[0].url} autoPlay={false} controls={false} className = "shadow-sm rounded" style = {{ width: '100%' }}/>
                 }
             </div>
             );

--- a/src/components/Post/BoostCard.tsx
+++ b/src/components/Post/BoostCard.tsx
@@ -1,14 +1,8 @@
 import React, {Component} from 'react';
-import {
-    DocumentCard,
-    DocumentCardTitle,
-    DocumentCardActivity,
-    DocumentCardType,
-    DocumentCardDetails,
-    PositioningContainer
-} from 'office-ui-fabric-react';
+import { DocumentCardActivity } from 'office-ui-fabric-react';
 import moment from 'moment';
 import ThreadPanel from '../ThreadPanel';
+import PostContent from '../Post/PostContent';
 import ProfilePanel from '../ProfilePanel';
 import {getTrueInitials} from '../../utilities/getTrueInitials';
 import Mastodon, { Status } from 'megalodon';
@@ -51,32 +45,9 @@ class BoostCard extends Component<IBoostCardProps, IBoostCardState> {
         return temporaryDiv.textContent || temporaryDiv.innerText || "";
     }
 
-    getCardStyles(status: Status) {
-        let documentCardStyles = {};
-
-            let actualContent = this.stripElementsFromContent(status.content);
-
-            if (status.media_attachments.length !== 0) {
-
-                documentCardStyles = {
-                    root: {
-                        height: 355
-                    }
-                }
-
-            } else if (actualContent.length > 150) {
-                documentCardStyles = {
-                    root: {
-                        height: 200
-                    }
-                }
-            }
-
-            return documentCardStyles;
-    }
-
     openChildThreadPanel() {
-        this.threadRef.current.openThreadPanel();
+        if (this.threadRef.current.getHiddenPanelState())
+            this.threadRef.current.openThreadPanel()
     }
 
     prepareMedia(media: any) {
@@ -120,46 +91,23 @@ class BoostCard extends Component<IBoostCardProps, IBoostCardState> {
     render() {
         let post = this.state.status;
         return(
-            <div id = {this.props.id}>
-            <div id="boost-card">
-                <ThreadPanel 
-                    fromWhere={post.id} 
-                    client={this.client} 
-                    fullButton={null}
-                    ref={this.threadRef}
-                />
-                <DocumentCard
-                    type={DocumentCardType.compact}
-                    styles={this.getCardStyles(post)}
-                    onClick={() => this.openChildThreadPanel()}
-                >
-                    <DocumentCardDetails>
-                        <DocumentCardTitle
-                            title={
-                                <div>
-                                    <p>{this.stripElementsFromContent(post.content)}</p>
-                                    {
-                                        post.media_attachments.length ?
-                                            <div className = "row">
-                                                {
-                                                    this.prepareMedia(post.media_attachments)
-                                                }
-                                            </div>:
-                                            <span/>
-                                    }
-                                </div> as unknown as string
-                            }
-                            shouldTruncate={true}
-                            showAsSecondaryTitle={true}
-                            styles={this.getCardStyles(post)}
-                        />
-                        <DocumentCardActivity
-                            activity={"Originally posted on " + moment(post.created_at).format("MMM Do, YYYY: h:mm A")}
-                            people={[{ name: <ProfilePanel account={post.account} client={this.client}/> as unknown as string, profileImageSrc: post.account.avatar, initials:getTrueInitials(post.account.display_name)}]}
-                        />
-                    </DocumentCardDetails>
-                </DocumentCard>
-            </div>
+            <div key = {this.props.id}>
+                <div id="boost-card" className = "boost-card" title={"Originally posted by " + post.account.acct} onClick = {() => this.openChildThreadPanel()}>
+                    <ThreadPanel 
+                        fromWhere={post.id} 
+                        client={this.client} 
+                        fullButton={null}
+                        ref={this.threadRef}
+                    />
+                    <PostContent contents={post.content}/>
+                    {post.media_attachments.length ? 
+                        <div className = "media">{this.prepareMedia(post.media_attachments)}</div>:<span/>
+                    }
+                    <DocumentCardActivity
+                        activity={"Originally posted on " + moment(post.created_at).format("MMM Do, YYYY: h:mm A")}
+                        people={[{ name: <ProfilePanel account={post.account} client={this.client}/> as unknown as string, profileImageSrc: post.account.avatar, initials:getTrueInitials(post.account.display_name)}]}
+                    />
+                </div>
             </div>
         );
     }

--- a/src/components/Post/BoostCard.tsx
+++ b/src/components/Post/BoostCard.tsx
@@ -5,7 +5,8 @@ import ThreadPanel from '../ThreadPanel';
 import PostContent from '../Post/PostContent';
 import ProfilePanel from '../ProfilePanel';
 import {getTrueInitials} from '../../utilities/getTrueInitials';
-import Mastodon, { Status } from 'megalodon';
+import Mastodon from 'megalodon';
+import { Status } from '../../types/Status';
 
 interface IBoostCardProps {
     client: Mastodon;

--- a/src/components/Post/BoostCard.tsx
+++ b/src/components/Post/BoostCard.tsx
@@ -21,7 +21,7 @@ interface IBoostCardState {
 /**
  * Small card element that displays a status. Usually used to display a reblogged
  * status.
- * 
+ *
  * @param client The Mastodon client used to view information about the status
  * @param status The status to display within the card itself
  */
@@ -54,9 +54,9 @@ class BoostCard extends Component<IBoostCardProps, IBoostCardState> {
                     media[0].type == "image" ?
                     <div className = "shadow-sm rounded" style = {
                         {
-                            backgroundImage: "url('" + media[0].url + "')", 
-                            backgroundPosition: "center", 
-                            backgroundSize: "cover", 
+                            backgroundImage: "url('" + media[0].url + "')",
+                            backgroundPosition: "center",
+                            backgroundSize: "cover",
                             backgroundRepeat: "no-repeat",
                             height: 250
                         }
@@ -88,14 +88,14 @@ class BoostCard extends Component<IBoostCardProps, IBoostCardState> {
         return(
             <div id = {this.props.id}>
                 <div id="boost-card" className = "boost-card" title={"Originally posted by " + post.account.acct} onClick = {() => this.openChildThreadPanel()}>
-                    <ThreadPanel 
-                        fromWhere={post.id} 
-                        client={this.client} 
+                    <ThreadPanel
+                        fromWhere={post.id}
+                        client={this.client}
                         fullButton={null}
                         ref={this.threadRef}
                     />
                     <PostContent contents={post.content}/>
-                    {post.media_attachments.length ? 
+                    {post.media_attachments.length ?
                         <div className = "media">{this.prepareMedia(post.media_attachments)}</div>:<span/>
                     }
                     <DocumentCardActivity

--- a/src/components/Post/BoostCard.tsx
+++ b/src/components/Post/BoostCard.tsx
@@ -85,7 +85,7 @@ class BoostCard extends Component<IBoostCardProps, IBoostCardState> {
     render() {
         let post = this.state.status;
         return(
-            <div key = {this.props.id}>
+            <div id = {this.props.id}>
                 <div id="boost-card" className = "boost-card" title={"Originally posted by " + post.account.acct} onClick = {() => this.openChildThreadPanel()}>
                     <ThreadPanel 
                         fromWhere={post.id} 

--- a/src/components/Post/BoostCard.tsx
+++ b/src/components/Post/BoostCard.tsx
@@ -94,7 +94,7 @@ class BoostCard extends Component<IBoostCardProps, IBoostCardState> {
                         fullButton={null}
                         ref={this.threadRef}
                     />
-                    <PostContent contents={post.content}/>
+                    <PostContent contents={post.content} emojis={post.emojis}/>
                     {post.media_attachments.length ?
                         <div className = "media">{this.prepareMedia(post.media_attachments)}</div>:<span/>
                     }

--- a/src/components/Post/BoostCard.tsx
+++ b/src/components/Post/BoostCard.tsx
@@ -101,6 +101,7 @@ class BoostCard extends Component<IBoostCardProps, IBoostCardState> {
                     <DocumentCardActivity
                         activity={"Posted on " + moment(post.created_at).format("MMM Do, YYYY: h:mm A")}
                         people={[{ name: <ProfilePanel account={post.account} client={this.client}/> as unknown as string, profileImageSrc: post.account.avatar, initials:getTrueInitials(post.account.display_name)}]}
+                        className="boost-persona"
                     />
                 </div>
             </div>

--- a/src/components/Post/PostContent.tsx
+++ b/src/components/Post/PostContent.tsx
@@ -1,9 +1,33 @@
 import React, {Component} from 'react';
+import {anchorInBrowser} from '../../utilities/anchorInBrowser';
+import {emojifyHTML} from '../../utilities/emojify';
 
-class PostContent extends Component {
+interface IPostContentProps {
+    contents: string;
+}
+
+interface IPostContentState {
+    contents: any;
+}
+
+class PostContent extends Component<IPostContentProps, IPostContentState> {
+
+    constructor(props: any) {
+        super(props);
+
+        this.state = {
+            contents: this.props.contents
+        }
+    }
+
+    componentDidUpdate() {
+        anchorInBrowser();
+    }
+
     render() {
+        //
         return (
-            <div className="post-content text-break">{this.props.children}</div>
+            <div className="post-content text-break" dangerouslySetInnerHTML={{__html: emojifyHTML(this.state.contents)}}></div>
         );
     }
 }

--- a/src/components/Post/PostContent.tsx
+++ b/src/components/Post/PostContent.tsx
@@ -1,9 +1,11 @@
 import React, {Component} from 'react';
 import {anchorInBrowser} from '../../utilities/anchorInBrowser';
 import {emojifyHTML} from '../../utilities/emojify';
+import { MastodonEmoji } from '../../types/Emojis';
 
 interface IPostContentProps {
     contents: string;
+    emojis?: [MastodonEmoji];
 }
 
 interface IPostContentState {
@@ -27,7 +29,10 @@ class PostContent extends Component<IPostContentProps, IPostContentState> {
     render() {
         //
         return (
-            <div className="post-content text-break" dangerouslySetInnerHTML={{__html: emojifyHTML(this.state.contents)}}></div>
+            <div>
+                <div className="post-content text-break" dangerouslySetInnerHTML={{__html: emojifyHTML(this.state.contents, this.props.emojis)}}></div>
+            </div>
+            
         );
     }
 }

--- a/src/components/Post/PostDate.tsx
+++ b/src/components/Post/PostDate.tsx
@@ -49,7 +49,7 @@ class PostDate extends Component<IPostDateProps, IPostDateState> {
     }
 
     parseDate(date: string): string {
-        return moment(date).format('MMMM do, Y [at] h:mm A');
+        return moment(date).format('MMMM Do, Y [at] h:mm A');
     }
 
     render() {

--- a/src/components/Post/PostDate.tsx
+++ b/src/components/Post/PostDate.tsx
@@ -49,7 +49,7 @@ class PostDate extends Component<IPostDateProps, IPostDateState> {
     }
 
     parseDate(date: string): string {
-        return moment(date).format('MM/DD/YYY [at] h:mm A');
+        return moment(date).format('MMMM do, Y [at] h:mm A');
     }
 
     render() {

--- a/src/components/Post/PostRoll.tsx
+++ b/src/components/Post/PostRoll.tsx
@@ -157,7 +157,7 @@ class PostRoll extends Component<IPostRollProps, IPostRollState> {
         this.client.get(where, params)
             .then((resp) => {
                 let data:any = resp.data;
-                let messages: any = [];
+                let messages: Status[] = [];
 
                 if (from == "messages") {
                     data.forEach((message: any) => {
@@ -165,6 +165,8 @@ class PostRoll extends Component<IPostRollProps, IPostRollState> {
                             messages.push(message.last_status as Status);
                         }
                     });
+                } else {
+                    messages = resp.data as [Status];
                 }
 
                 _this.setState({

--- a/src/components/Post/PostRoll.tsx
+++ b/src/components/Post/PostRoll.tsx
@@ -1,7 +1,8 @@
-import Mastodon, {Status, Response} from "megalodon";
+import Mastodon from "megalodon";
 import React, {Component} from 'react';
 import {Link, Spinner, SpinnerSize} from 'office-ui-fabric-react';
 import Post from './index';
+import { Status } from '../../types/Status';
 
 
 interface IPostRollProps {
@@ -10,7 +11,7 @@ interface IPostRollProps {
 }
 
 interface IPostRollState {
-    statuses: Array<any>;
+    statuses: Array<Status>;
     statusCount: Number;
     loading: boolean;
 }
@@ -127,7 +128,7 @@ class PostRoll extends Component<IPostRollProps, IPostRollState> {
         this.streamListener.on('delete', (delId: Number) => {
             let roll = _this.state.statuses;
             for (let i in roll) {
-                if (roll[Number(i)].id === delId) {
+                if (roll[Number(i)].id === delId.toString()) {
                     roll.splice(Number(i), 1);
                 }
             }
@@ -161,14 +162,13 @@ class PostRoll extends Component<IPostRollProps, IPostRollState> {
                 if (from == "messages") {
                     data.forEach((message: any) => {
                         if (message.last_status !== null) {
-                            console.log(status);
-                            messages.push(message.last_status);
+                            messages.push(message.last_status as Status);
                         }
                     });
                 }
 
                 _this.setState({
-                    statuses: _this.state.statuses.concat(resp.data) || messages,
+                    statuses: _this.state.statuses.concat(messages) || messages,
                     statusCount: 20 + _this.state.statuses.length
                 } as unknown as IPostRollState);
             });

--- a/src/components/Post/PostRoll.tsx
+++ b/src/components/Post/PostRoll.tsx
@@ -140,16 +140,16 @@ class PostRoll extends Component<IPostRollProps, IPostRollState> {
         let _this = this;
         let last_status = this.state.statuses[this.state.statuses.length - 1].id;
         let where = "";
-        let params = {"max_id": last_status, "local": false}
+        let params = {max_id: last_status, local: false}
 
-        if (from == "home") {
+        if (from === "home") {
             where = "/timelines/home";
-        } else if (from == "local") {
-            where = "timelines/public";
-            params = {"max_id": last_status, "local": true}
-        } else if (from == "public") {
+        } else if (from === "local") {
             where = "/timelines/public";
-        } else if (from == "conversations") {
+            params.local = true;
+        } else if (from === "public") {
+            where = "/timelines/public";
+        } else if (from === "conversations") {
             where = "/conversations";
         }
 

--- a/src/components/Post/PostRoll.tsx
+++ b/src/components/Post/PostRoll.tsx
@@ -90,7 +90,6 @@ class PostRoll extends Component<IPostRollProps, IPostRollState> {
                         
                         data.forEach((message: any) => {
                             if (message.last_status !== null) {
-                                console.log(status);
                                 messages.push(message.last_status);
                             }
                         });

--- a/src/components/Post/PostSensitive.tsx
+++ b/src/components/Post/PostSensitive.tsx
@@ -59,9 +59,9 @@ class PostSensitive extends Component<IPostSensitiveProps, IPostSensitiveState> 
 
     flagColorOfButton(spoiler: string) {
         if (spoiler.includes('NSFW: ')) {
-            return [ColorClassNames.redDarkBackground, ColorClassNames.redDarkBackgroundHover, ColorClassNames.white, ColorClassNames.whiteHover].toString();
+            return 'cw-button-nsfw';
         } else if (spoiler.includes('Spoiler: ')) {
-            return [ColorClassNames.yellowBackground, ColorClassNames.yellowBackgroundHover].toString();
+            return 'cw-button-spoiler';
         } else {
             return "";
         }

--- a/src/components/Post/PostSensitive.tsx
+++ b/src/components/Post/PostSensitive.tsx
@@ -3,11 +3,12 @@ import {CompoundButton, Dialog, DialogType} from "office-ui-fabric-react";
 import {ColorClassNames} from '@uifabric/styling';
 import {anchorInBrowser} from "../../utilities/anchorInBrowser";
 import {getDarkMode} from "../../utilities/getDarkMode";
-import { Status } from 'megalodon';
+import { Status } from '../../types/Status';
+import { Attachment } from '../../types/Attachment';
 import Carousel from 'nuka-carousel';
 
 interface IPostSensitiveProps {
-    status: any;
+    status: Status;
 }
 
 interface IPostSensitiveState {
@@ -74,7 +75,7 @@ class PostSensitive extends Component<IPostSensitiveProps, IPostSensitiveState> 
         }
     }
 
-    prepareMedia(media: any) {
+    prepareMedia(media: [Attachment]) {
         if (media.length >= 2) {
             let id = "mediaControl";
             return (
@@ -89,12 +90,12 @@ class PostSensitive extends Component<IPostSensitiveProps, IPostSensitiveState> 
                         initialSlideHeight={350}
                     >
                     {
-                            media.map((item: any) => {
+                            media.map((item: Attachment) => {
                                 return (
                                     <span>
                                         {
                                             (item.type === "image") ?
-                                                <img className="rounded shadow-sm" src={item.url} alt={item.description} style={{width: "100%", minHeight: 350}}/>:
+                                                <img className="rounded shadow-sm" src={item.url} alt={item.description? item.description: ''} style={{width: "100%", minHeight: 350}}/>:
                                                 <video className="rounded shadow-sm" src={item.url} autoPlay={false} controls={true} style={{width: "100%", minHeight: 350}}/>
                                         }
                                     </span>
@@ -109,7 +110,7 @@ class PostSensitive extends Component<IPostSensitiveProps, IPostSensitiveState> 
             <div className = "col">
                 {
                     (media[0].type === "image") ?
-                        <img src={media[0].url} className = "shadow-sm rounded" alt={media[0].description} style = {{ width: '100%' }}/>:
+                        <img src={media[0].url} className = "shadow-sm rounded" alt={media[0].description? media[0].description: ''} style = {{ width: '100%' }}/>:
                         <video src={media[0].url} autoPlay={false} controls={true} className = "shadow-sm rounded" style = {{ width: '100%' }}/>
                 }
             </div>

--- a/src/components/Post/PostToolbar.tsx
+++ b/src/components/Post/PostToolbar.tsx
@@ -3,11 +3,12 @@ import {ActionButton, TooltipHost, Dialog, DialogType, DialogFooter, PrimaryButt
 import ReplyWindow from '../ReplyWindow';
 import ThreadPanel from '../ThreadPanel';
 import { getDarkMode } from '../../utilities/getDarkMode';
-import Mastodon, { Status } from 'megalodon';
+import Mastodon from 'megalodon';
 import { ToastConsumer } from 'react-awesome-toasts';
+import { Status } from '../../types/Status';
 interface IPostToolbarProps {
     client: Mastodon;
-    status: any;
+    status: Status;
     nothread: boolean | undefined;
 }
 
@@ -18,8 +19,8 @@ interface IPostToolbarState {
     boosts: number;
     favorited: boolean | null;
     boosted: boolean | null;
-    favorite_toggle: boolean | undefined;
-    url: string;
+    favorite_toggle: boolean | null;
+    url: string | null;
     noThread: boolean | undefined;
     hideDeleteDialog: boolean | undefined;
 }
@@ -43,7 +44,7 @@ class PostToolbar extends Component<IPostToolbarProps, IPostToolbarState> {
         this.client = this.props.client;
 
         this.state = {
-            id: this.props.status.id,
+            id: Number(this.props.status.id),
             replies: this.props.status.replies_count,
             favorites: this.props.status.favourites_count,
             boosts: this.props.status.reblogs_count,
@@ -223,7 +224,7 @@ class PostToolbar extends Component<IPostToolbarProps, IPostToolbarState> {
                                             checked={false}
                                             onClick={() => 
                                                 {
-                                                    this.getLinkAndCopy(this.state.url); 
+                                                    this.getLinkAndCopy(this.state.url? this.state.url: ''); 
                                                     show({... {text: 'Link copied!'}, onActionClick: hide});
                                                 }
                                             }

--- a/src/components/Post/PostToolbar.tsx
+++ b/src/components/Post/PostToolbar.tsx
@@ -28,7 +28,7 @@ interface IPostToolbarState {
 /**
  * A small toolbar including common actions for interacting with
  * a post.
- * 
+ *
  * @param client The client used to ineract with a post.
  * @param status The post to interact with.
  * @param nothread Whether to hide the 'Show thread' button
@@ -36,7 +36,7 @@ interface IPostToolbarState {
 class PostToolbar extends Component<IPostToolbarProps, IPostToolbarState> {
 
     client: any;
-    
+
 
     constructor(props: any) {
         super(props);
@@ -222,9 +222,9 @@ class PostToolbar extends Component<IPostToolbarProps, IPostToolbarState> {
                                             allowDisabledFocus={true}
                                             disabled={false}
                                             checked={false}
-                                            onClick={() => 
+                                            onClick={() =>
                                                 {
-                                                    this.getLinkAndCopy(this.state.url? this.state.url: ''); 
+                                                    this.getLinkAndCopy(this.state.url? this.state.url: '');
                                                     show({... {text: 'Link copied!'}, onActionClick: hide});
                                                 }
                                             }

--- a/src/components/Post/PostToolbar.tsx
+++ b/src/components/Post/PostToolbar.tsx
@@ -13,7 +13,7 @@ interface IPostToolbarProps {
 }
 
 interface IPostToolbarState {
-    id: number;
+    id: string;
     replies: number;
     favorites: number;
     boosts: number;
@@ -44,7 +44,7 @@ class PostToolbar extends Component<IPostToolbarProps, IPostToolbarState> {
         this.client = this.props.client;
 
         this.state = {
-            id: Number(this.props.status.id),
+            id: this.props.status.id,
             replies: this.props.status.replies_count,
             favorites: this.props.status.favourites_count,
             boosts: this.props.status.reblogs_count,

--- a/src/components/Post/index.tsx
+++ b/src/components/Post/index.tsx
@@ -73,7 +73,7 @@ class Post extends Component<IPostProps, IPostState> {
     }
 
     getAuthorName(account: any) {
-        return emojifyHTML(account.display_name) || account.acct;
+        return emojifyHTML(account.display_name, account.emojis) || account.acct;
     }
 
     getPersonaText(index: any) {
@@ -192,21 +192,24 @@ class Post extends Component<IPostProps, IPostState> {
                         autoplay={false}
                         slideIndex={this.state.carouselIndex}
                         afterSlide={(newIndex: number) => { this.setState({carouselIndex: newIndex})}}
-                        width="100%"
                         heightMode="current"
                         initialSlideHeight={350}
                         className="carousel-area"
+                        cellSpacing={100}
                     >
                     {
                             media.map((item: Attachment) => {
                                 return (
-                                    <span>
-                                        {
-                                            (item.type === "image") ?
-                                                <img className="rounded shadow-sm" src={item.url} alt={item.description? item.description: ''} style={{width: "100%", minHeight: 350}}/>:
-                                                <video className="rounded shadow-sm" src={item.url} autoPlay={false} controls={true} style={{width: "100%", minHeight: 350}}/>
-                                        }
-                                    </span>
+                                    <div className = "shadow-sm rounded post-carousel-item">
+                                        <div className="item-bg" style={{backgroundImage: 'url("' + item.url + '")'}}/>
+                                        <div className="item-content-container">
+                                            {
+                                                (item.type === "image") ?
+                                                    <img src={item.url} alt={item.description? item.description: ''} className="item-content"/>:
+                                                    <video src={item.url} autoPlay={false} controls={true} style={{width: "auto", height: '100%'}} className="item-content"/>
+                                            }
+                                        </div>
+                                    </div>
                                 );
                             })
                         }

--- a/src/components/Post/index.tsx
+++ b/src/components/Post/index.tsx
@@ -13,6 +13,7 @@ import { getTrueInitials } from "../../utilities/getTrueInitials";
 import Mastodon, { Status } from 'megalodon';
 import ThreadPanel from '../ThreadPanel';
 import Carousel from 'nuka-carousel';
+import { emojifyHTML } from '../../utilities/emojify';
 
 interface IPostProps {
     client: Mastodon;
@@ -72,12 +73,12 @@ class Post extends Component<IPostProps, IPostState> {
     }
 
     getAuthorName(account: any) {
-        return account.display_name || account.acct;
+        return emojifyHTML(account.display_name) || account.acct;
     }
 
     getPersonaText(index: any) {
         if (this.state.noLink) {
-            return <b>{this.getAuthorName(this.props.status.account)}</b>;
+            return <b className = "profile-name" dangerouslySetInnerHTML={{__html: this.getAuthorName(this.props.status.account)}}></b>;
         } else {
             return <ProfilePanel account={this.props.status.account} client={this.client} key={this.props.status.account.id.toString() + "_" + index.toString() + "_panel"}/>;
         }
@@ -136,7 +137,7 @@ class Post extends Component<IPostProps, IPostState> {
 
         let passClass = (() => {
             let test = true;
-            if (typeof(event.target.className.includes) === "function" || event.target.className !== undefined || event.target.className !== "") {
+            if (typeof(event.target.className.includes) === "function") {
                 unacceptableClasses.forEach(element => {
                     if (event.target.className.includes(element) || parent.className.includes(element))
                         test = false;

--- a/src/components/Post/index.tsx
+++ b/src/components/Post/index.tsx
@@ -251,7 +251,7 @@ class Post extends Component<IPostProps, IPostState> {
 
                 <div className="mb-2" key={this.props.status.id.toString() + "_contents"}>
                     {
-                        this.props.status.reblog ? 
+                        this.props.status.reblog ?
                         this.getBoostCard(this.props.status):
                             this.props.status.sensitive === true?
                             <PostSensitive status={this.props.status} key={this.props.status.id.toString() + "_sensitive"}/>:

--- a/src/components/Post/index.tsx
+++ b/src/components/Post/index.tsx
@@ -129,9 +129,7 @@ class Post extends Component<IPostProps, IPostState> {
             "slider",
             "ms-Panel-main",
             "clickable-link",
-            "ms-DocumentCard-title",
-            "ms-DocumentCard-details",
-            "ms-DocumentCard"
+            "boost-card"
         ]
         let unacceptableNodeTypes = ["A", "BUTTON"]
 

--- a/src/components/Post/index.tsx
+++ b/src/components/Post/index.tsx
@@ -1,26 +1,26 @@
 import React, { Component } from 'react';
-import { Persona, TooltipHost } from "office-ui-fabric-react";
-import moment from 'moment';
+import { Persona } from "office-ui-fabric-react";
 import PostContent from './PostContent';
 import PostDate from './PostDate';
 import PostToolbar from './PostToolbar';
 import PostSensitive from './PostSensitive';
 import ProfilePanel from '../ProfilePanel';
 import BoostCard from './BoostCard';
-import { getInitials } from '@uifabric/utilities/lib/initials.js';
 import {anchorInBrowser} from "../../utilities/anchorInBrowser";
 import { getTrueInitials } from "../../utilities/getTrueInitials";
-import Mastodon, { Status } from 'megalodon';
+import Mastodon from 'megalodon';
 import ThreadPanel from '../ThreadPanel';
 import Carousel from 'nuka-carousel';
 import { emojifyHTML } from '../../utilities/emojify';
+import { Status } from '../../types/Status';
+import { Attachment } from '../../types/Attachment';
 
 interface IPostProps {
     client: Mastodon;
     nolink?: boolean | undefined;
     nothread?: boolean | undefined;
     bigShadow?: boolean | undefined;
-    status: any;
+    status: Status;
     clickToThread?: boolean;
 }
 
@@ -165,12 +165,12 @@ class Post extends Component<IPostProps, IPostState> {
     }
 
     getBoostCard(status: Status) {
-        if (status.reblog) {
+        if (status.reblog != null) {
             return (
                 <div className='mt-1 ml-4 mb-1'>
                     <div key={status.id.toString() + "_boost"}>
                         { status.reblog.sensitive === true ?
-                            <PostSensitive status={this.props.status.reblog} key={status.reblog.id.toString() + "_sensitive_boost"}/>:
+                            <PostSensitive status={this.props.status.reblog as Status} key={status.reblog.id.toString() + "_sensitive_boost"}/>:
 
                             <div className='ml-4 mb-2'>
                                 <BoostCard id = {this.props.status.id + "-boost-card"} client={this.client} status={this.props.status.reblog as Status}/>
@@ -182,7 +182,7 @@ class Post extends Component<IPostProps, IPostState> {
         }
     }
 
-    prepareMedia(media: any) {
+    prepareMedia(media: [Attachment]) {
         if (media.length >= 2) {
             let id = "mediaControl";
             return (
@@ -198,12 +198,12 @@ class Post extends Component<IPostProps, IPostState> {
                         className="carousel-area"
                     >
                     {
-                            media.map((item: any) => {
+                            media.map((item: Attachment) => {
                                 return (
                                     <span>
                                         {
                                             (item.type === "image") ?
-                                                <img className="rounded shadow-sm" src={item.url} alt={item.description} style={{width: "100%", minHeight: 350}}/>:
+                                                <img className="rounded shadow-sm" src={item.url} alt={item.description? item.description: ''} style={{width: "100%", minHeight: 350}}/>:
                                                 <video className="rounded shadow-sm" src={item.url} autoPlay={false} controls={true} style={{width: "100%", minHeight: 350}}/>
                                         }
                                     </span>
@@ -218,7 +218,7 @@ class Post extends Component<IPostProps, IPostState> {
             <div className = "col">
                 {
                     (media[0].type === "image") ?
-                        <img src={media[0].url} className = "shadow-sm rounded" alt={media[0].description} style = {{ width: '100%' }}/>:
+                        <img src={media[0].url} className = "shadow-sm rounded" alt={media[0].description? media[0].description: ''} style = {{ width: '100%' }}/>:
                         <video src={media[0].url} autoPlay={false} controls={true} className = "shadow-sm rounded" style = {{ width: '100%' }}/>
                 }
             </div>

--- a/src/components/Post/index.tsx
+++ b/src/components/Post/index.tsx
@@ -34,7 +34,7 @@ interface IPostState {
 
 /**
  * Basic element for rendering a post on Mastodon
- * 
+ *
  * @param client The client used to get/post information from Mastodon
  * @param status The post to display and interact with
  * @param nolink Whether the post shouldn't link the author's profile panel
@@ -120,17 +120,17 @@ class Post extends Component<IPostProps, IPostState> {
     openThreadPanel(event: any) {
         let parent = event.target.parentNode;
         let unacceptableClasses = [
-            "d-none", 
-            "carousel-area", 
-            "slider-control-", 
-            "ms-Link", 
-            "ms-Button", 
-            "ms-Button-flexContainer", 
-            "slider", 
-            "ms-Panel-main", 
-            "clickable-link", 
-            "ms-DocumentCard-title", 
-            "ms-DocumentCard-details", 
+            "d-none",
+            "carousel-area",
+            "slider-control-",
+            "ms-Link",
+            "ms-Button",
+            "ms-Button-flexContainer",
+            "slider",
+            "ms-Panel-main",
+            "clickable-link",
+            "ms-DocumentCard-title",
+            "ms-DocumentCard-details",
             "ms-DocumentCard"
         ]
         let unacceptableNodeTypes = ["A", "BUTTON"]
@@ -230,9 +230,9 @@ class Post extends Component<IPostProps, IPostState> {
 
     render() {
         return (
-        <div 
+        <div
             id={this.state.id}
-            key={this.props.status.id + "_post"} 
+            key={this.props.status.id + "_post"}
             className={"container rounded p-3 ms-slideDownIn10 marked-area " + this.getBigShadow()}
             onClick={(e) => {
                 if (this.state.clickToThread) {
@@ -267,7 +267,7 @@ class Post extends Component<IPostProps, IPostState> {
                                         <span/>
                                 }
                             </div>
-                            
+
                     }
                 </div>
 

--- a/src/components/Post/index.tsx
+++ b/src/components/Post/index.tsx
@@ -72,17 +72,7 @@ class Post extends Component<IPostProps, IPostState> {
     }
 
     getAuthorName(account: any) {
-        let x;
-        try {
-            x = account.display_name;
-            if (x === '') {
-                x = account.acct;
-            }
-            getInitials(x, false);
-        } catch (error) {
-            x = account.acct;
-        }
-        return x
+        return account.display_name || account.acct;
     }
 
     getPersonaText(index: any) {
@@ -258,31 +248,28 @@ class Post extends Component<IPostProps, IPostState> {
                         } } />
                 }
 
-                <PostContent>
+                <div className="mb-2" key={this.props.status.id.toString() + "_contents"}>
                     {
-
-                        this.props.status.reblog ?
-                            this.getBoostCard(this.props.status):
-
-                            <div className='mb-2' key={this.props.status.id.toString() + "_contents"}>
-                                { this.props.status.sensitive === true ?
-                                    <PostSensitive status={this.props.status} key={this.props.status.id.toString() + "_sensitive"}/>:
-                                    <div>
-                                        <p dangerouslySetInnerHTML={{__html: this.props.status.content}} />
-                                        {
-                                            this.props.status.media_attachments.length ?
-                                                <div className = "row">
-                                                    {
-                                                        this.prepareMedia(this.props.status.media_attachments)
-                                                    }
-                                                </div>:
-                                                <span/>
-                                        }
-                                    </div>}
+                        this.props.status.reblog ? 
+                        this.getBoostCard(this.props.status):
+                            this.props.status.sensitive === true?
+                            <PostSensitive status={this.props.status} key={this.props.status.id.toString() + "_sensitive"}/>:
+                            <div>
+                                <PostContent contents={this.props.status.content}/>
+                                {
+                                    this.props.status.media_attachments.length ?
+                                        <div className = "row">
+                                            {
+                                                this.prepareMedia(this.props.status.media_attachments)
+                                            }
+                                        </div>:
+                                        <span/>
+                                }
                             </div>
+                            
                     }
+                </div>
 
-                </PostContent>
                 <PostToolbar
                     client={this.props.client}
                     status={this.props.status}

--- a/src/components/Post/index.tsx
+++ b/src/components/Post/index.tsx
@@ -254,7 +254,7 @@ class Post extends Component<IPostProps, IPostState> {
                             this.props.status.sensitive === true?
                             <PostSensitive status={this.props.status} key={this.props.status.id.toString() + "_sensitive"}/>:
                             <div>
-                                <PostContent contents={this.props.status.content}/>
+                                <PostContent contents={this.props.status.content} emojis={this.props.status.emojis}/>
                                 {
                                     this.props.status.media_attachments.length ?
                                         <div className = "row">

--- a/src/components/ProfileContainer/index.tsx
+++ b/src/components/ProfileContainer/index.tsx
@@ -10,14 +10,15 @@ import {
 import AccountPanel from '../AccountPanel';
 import { getTrueInitials } from "../../utilities/getTrueInitials";
 import Mastodon from 'megalodon';
+import { Account } from '../../types/Account';
 
 interface IProfileProps {
-    who: any;
+    who: Account;
     client: Mastodon;
 }
 
 export class ProfileUser extends Component<IProfileProps> {
-    who: any;
+    who: Account;
     persona: any;
     client: any;
 
@@ -126,7 +127,7 @@ class ProfileContainer extends Component<IProfileProps> {
                             client={this.props.client}
                         />
                     </div>
-                    <Label>{this.who.source.note}</Label>
+                    <div className = "profile-container-biography" dangerouslySetInnerHTML={{__html: this.who.note}}></div>
                     <ProfileList who={this.who}/>
                 </div>
             </div>

--- a/src/components/ProfilePanel/index.tsx
+++ b/src/components/ProfilePanel/index.tsx
@@ -123,7 +123,7 @@ class ProfilePanel extends Component<IProfilePanelProps, IProfilePanelState> {
     }
 
     checkDisplayName(account: any) {
-        return emojifyHTML(account.display_name) || account.username;
+        return emojifyHTML(account.display_name, account.emojis) || account.username;
     }
 
     getProfileMetadata(account: any) {

--- a/src/components/ProfilePanel/index.tsx
+++ b/src/components/ProfilePanel/index.tsx
@@ -7,6 +7,7 @@ import Post from '../Post';
 import {anchorInBrowser} from "../../utilities/anchorInBrowser";
 import { getTrueInitials } from "../../utilities/getTrueInitials";
 import {getDarkMode} from "../../utilities/getDarkMode";
+import {emojifyHTML} from '../../utilities/emojify';
 import Mastodon, { Status } from 'megalodon';
 
 interface IProfilePanelProps {
@@ -69,9 +70,9 @@ class ProfilePanel extends Component<IProfilePanelProps, IProfilePanelState> {
     createProfileLinkByName() {
         return (
             <span>
-                <Link onClick={() => this.toggleProfilePanel()} style={{
+                <Link className = "profile-name" onClick={() => this.toggleProfilePanel()} style={{
                     fontWeight: 'bold'
-                }}>{this.checkDisplayName(this.state.account)}</Link>
+                }} dangerouslySetInnerHTML={{__html: this.checkDisplayName(this.state.account)}}/>
             </span>
         );
     }
@@ -121,11 +122,7 @@ class ProfilePanel extends Component<IProfilePanelProps, IProfilePanelState> {
     }
 
     checkDisplayName(account: any) {
-        if (account.display_name === "") {
-            return account.username;
-        } else {
-            return account.display_name;
-        }
+        return emojifyHTML(account.display_name) || account.username;
     }
 
     getProfileMetadata(account: any) {
@@ -140,7 +137,7 @@ class ProfilePanel extends Component<IProfilePanelProps, IProfilePanelState> {
                         {
                             imageUrl: this.state.account.avatar,
                             imageInitials: getTrueInitials(this.state.account.display_name),
-                            text: this.checkDisplayName(this.state.account),
+                            text: (<span dangerouslySetInnerHTML={{__html: this.checkDisplayName(this.state.account)}}/> as unknown as string),
                             secondaryText: '@' + this.state.account.username,
                             tertiaryText: this.getProfileMetadata(this.state.account)
                         }
@@ -165,6 +162,7 @@ class ProfilePanel extends Component<IProfilePanelProps, IProfilePanelState> {
                             }
                         }
                     }
+                    className = "profile-persona"
                 />
                 <PrimaryButton
                     text={this.returnFollowStatusText()}

--- a/src/components/ProfilePanel/index.tsx
+++ b/src/components/ProfilePanel/index.tsx
@@ -8,7 +8,8 @@ import {anchorInBrowser} from "../../utilities/anchorInBrowser";
 import { getTrueInitials } from "../../utilities/getTrueInitials";
 import {getDarkMode} from "../../utilities/getDarkMode";
 import {emojifyHTML} from '../../utilities/emojify';
-import Mastodon, { Status } from 'megalodon';
+import Mastodon from 'megalodon';
+import { Status } from '../../types/Status';
 
 interface IProfilePanelProps {
     client: Mastodon;

--- a/src/components/ReplyWindow/index.tsx
+++ b/src/components/ReplyWindow/index.tsx
@@ -50,7 +50,7 @@ interface IReplyWindowState {
 /**
  * Offspring of the ComposeWindow component. Displays a status and
  * offers a compose window for crafting a reply to the post.
- * 
+ *
  * @param client The client used to post the reply with
  * @param status The status to reply to
  */
@@ -444,8 +444,8 @@ class ReplyWindow extends Component<IReplyWindowProps, IReplyWindowState> {
             onDismiss={() => this.toggleEmojiPicker()}
             target={document.getElementById('emojiPickerReplyButton')}
         >
-            <EmojiPicker 
-                onEmojiClick={(e: Event) => this.addEmojiToStatus(e)} 
+            <EmojiPicker
+                onEmojiClick={(e: Event) => this.addEmojiToStatus(e)}
                 assetPath="./images/emoji"
                 emojiResolution={128}
             />

--- a/src/components/ThreadPanel/index.js
+++ b/src/components/ThreadPanel/index.js
@@ -34,6 +34,17 @@ class ThreadPanel extends Component {
         }
 
         this.client = this.props.client;
+        this.toggleState = this.toggleState.bind(this);
+    }
+
+    getHiddenPanelState() {
+        return this.state.hideThreadPanel;
+    }
+
+    toggleState() {
+        this.setState({
+            hideThreadPanel: !this.state.hideThreadPanel
+        })
     }
 
     openThreadPanel() {

--- a/src/types/Account.tsx
+++ b/src/types/Account.tsx
@@ -1,6 +1,9 @@
 import { MastodonEmoji } from './Emojis';
 import { Field } from './Field';
 
+/**
+ * Basic type for an account on Mastodon
+ */
 export type Account = {
     id: string;
     username: string;

--- a/src/types/Account.tsx
+++ b/src/types/Account.tsx
@@ -1,0 +1,24 @@
+import { MastodonEmoji } from './Emojis';
+import { Field } from './Field';
+
+export type Account = {
+    id: string;
+    username: string;
+    acct: string;
+    display_name: string;
+    locked: boolean;
+    created_at: string;
+    followers_count: number;
+    following_count: number;
+    statuses_count: number;
+    note: string;
+    url: string;
+    avatar: string;
+    avatar_static: string;
+    header: string;
+    header_static: string;
+    emojis: [MastodonEmoji];
+    moved: Account | null;
+    fields: [Field];
+    bot: boolean | null;
+}

--- a/src/types/Attachment.tsx
+++ b/src/types/Attachment.tsx
@@ -1,3 +1,6 @@
+/**
+ * Basic type for an attachment, usually on Statuses
+ */
 export type Attachment = {
     id: string;
     type: "unknown" | "image" | "gifv" | "video";

--- a/src/types/Attachment.tsx
+++ b/src/types/Attachment.tsx
@@ -1,0 +1,10 @@
+export type Attachment = {
+    id: string;
+    type: "unknown" | "image" | "gifv" | "video";
+    url: string;
+    remote_url: string | null;
+    preview_url: string;
+    text_url: string | null;
+    meta: any | null;
+    description: string | null;
+}

--- a/src/types/Card.tsx
+++ b/src/types/Card.tsx
@@ -1,0 +1,14 @@
+export type Card = {
+    url: string;
+    title: string;
+    description: string;
+    image: string | null;
+    type: "link" | "photo" | "video" | "rich";
+    author_name: string | null;
+    author_url: string | null;
+    provider_name: string | null;
+    provider_url: string | null;
+    html: string | null;
+    width: number | null;
+    height: number | null;
+}

--- a/src/types/Card.tsx
+++ b/src/types/Card.tsx
@@ -1,3 +1,6 @@
+/**
+ * Basic type for Cards, usually in Statuses
+ */
 export type Card = {
     url: string;
     title: string;

--- a/src/types/Emojis.tsx
+++ b/src/types/Emojis.tsx
@@ -4,3 +4,8 @@ export type MastodonEmoji = {
     url: string;
     visible_in_picker: boolean;
 };
+
+export type Emoji = {
+    name: string;
+    imageUrl: string;
+};

--- a/src/types/Emojis.tsx
+++ b/src/types/Emojis.tsx
@@ -1,0 +1,6 @@
+export type MastodonEmoji = {
+    shortcode: string;
+    static_url: string;
+    url: string;
+    visible_in_picker: boolean;
+};

--- a/src/types/Emojis.tsx
+++ b/src/types/Emojis.tsx
@@ -1,3 +1,6 @@
+/**
+ * Basic type for Emojis on Mastodon.
+ */
 export type MastodonEmoji = {
     shortcode: string;
     static_url: string;
@@ -5,6 +8,9 @@ export type MastodonEmoji = {
     visible_in_picker: boolean;
 };
 
+/**
+ * Trimmed type of Emoji from emoji-mart
+ */
 export type Emoji = {
     name: string;
     imageUrl: string;

--- a/src/types/Field.tsx
+++ b/src/types/Field.tsx
@@ -1,3 +1,6 @@
+/**
+ * Basic type for a table entry, usually in Account
+ */
 export type Field = {
     name: string;
     value: string;

--- a/src/types/Field.tsx
+++ b/src/types/Field.tsx
@@ -1,0 +1,5 @@
+export type Field = {
+    name: string;
+    value: string;
+    verified_at: string | null;
+}

--- a/src/types/Mention.tsx
+++ b/src/types/Mention.tsx
@@ -1,0 +1,6 @@
+export type Mention = {
+    url: string;
+    username: string;
+    acct: string;
+    id: string;
+}

--- a/src/types/Mention.tsx
+++ b/src/types/Mention.tsx
@@ -1,3 +1,6 @@
+/**
+ * Basic type for a person mentioned in a Status
+ */
 export type Mention = {
     url: string;
     username: string;

--- a/src/types/Poll.tsx
+++ b/src/types/Poll.tsx
@@ -1,3 +1,6 @@
+/**
+ * Basic type for a Poll on Mastodon
+ */
 export type Poll = {
     id: string;
     expires_at: string | null;
@@ -8,6 +11,9 @@ export type Poll = {
     voted: boolean | null;
 }
 
+/**
+ * Basic type for a Poll option in a Poll
+ */
 export type PollOption = {
     title: string;
     votes_count: number | null;

--- a/src/types/Poll.tsx
+++ b/src/types/Poll.tsx
@@ -1,0 +1,14 @@
+export type Poll = {
+    id: string;
+    expires_at: string | null;
+    expired: boolean;
+    multiple: boolean;
+    votes_count: number;
+    options: [PollOption];
+    voted: boolean | null;
+}
+
+export type PollOption = {
+    title: string;
+    votes_count: number | null;
+}

--- a/src/types/Status.tsx
+++ b/src/types/Status.tsx
@@ -1,0 +1,36 @@
+import { MastodonEmoji } from './Emojis';
+import { Visibility } from './Visibility';
+import { Account } from './Account';
+import { Attachment } from './Attachment';
+import { Mention } from './Mention';
+import { Poll } from './Poll';
+import { Card } from './Card';
+
+export type Status = {
+    id: string;
+    uri: string;
+    url: string | null;
+    account: Account;
+    in_reply_to_id: string | null;
+    in_reply_to_account_id: string | null;
+    reblog: Status | null;
+    content: string;
+    created_at: string;
+    emojis: [MastodonEmoji];
+    replies_count: number;
+    reblogs_count: number;
+    favourites_count: number;
+    reblogged: boolean | null;
+    favourited: boolean | null;
+    muted: boolean | null;
+    sensitive: boolean;
+    spoiler_text: string;
+    visibility: Visibility;
+    media_attachements: [Attachment];
+    mentions: [Mention];
+    tags: any;
+    card: Card | null;
+    poll: Poll | null;
+    application: any;
+    pinned: boolean | null;
+}

--- a/src/types/Status.tsx
+++ b/src/types/Status.tsx
@@ -26,7 +26,7 @@ export type Status = {
     sensitive: boolean;
     spoiler_text: string;
     visibility: Visibility;
-    media_attachements: [Attachment];
+    media_attachments: [Attachment];
     mentions: [Mention];
     tags: any;
     card: Card | null;

--- a/src/types/Status.tsx
+++ b/src/types/Status.tsx
@@ -6,6 +6,9 @@ import { Mention } from './Mention';
 import { Poll } from './Poll';
 import { Card } from './Card';
 
+/**
+ * Basic type for a status on Mastodon
+ */
 export type Status = {
     id: string;
     uri: string;

--- a/src/types/Visibility.tsx
+++ b/src/types/Visibility.tsx
@@ -1,1 +1,4 @@
+/**
+ * Types of a post's visibility on Mastodon.
+ */
 export type Visibility = "direct" | "private" | "unlisted" | "public";

--- a/src/utilities/emojify.ts
+++ b/src/utilities/emojify.ts
@@ -1,11 +1,12 @@
-import {Emoji} from '../types/Emojis';
+import {Emoji, MastodonEmoji} from '../types/Emojis';
 
 /**
  * Takes a given string and inserts the correct emoji elements.
  * @param content The HTML string to locate and replace emojis with
+ * @param extraEmojis Any additional emojis that should be rendered
  * @returns HTML string with emojis as `img` elements
  */
-export function emojifyHTML(content: string): string {
+export function emojifyHTML(content: string, extraEmojis?: [MastodonEmoji]): string {
     const div = document.createElement('div');
     let html = content;
     let emojis: [Emoji] = JSON.parse(localStorage.getItem("emojis") as string);
@@ -14,6 +15,12 @@ export function emojifyHTML(content: string): string {
             let regexp = new RegExp(':' + emoji.name + ':', 'g');
             html = html.replace(regexp, `<img src="${emoji.imageUrl}" class="emoji"/>`);
         });
+    }
+    if (extraEmojis !== undefined && extraEmojis.length > 0) {
+        extraEmojis.forEach((emoji: MastodonEmoji) => {
+            let regexp = new RegExp(':' + emoji.shortcode + ':', 'g');
+            html = html.replace(regexp, `<img src="${emoji.static_url}" class="emoji"/>`)
+        })
     }
     
     div.innerHTML = html;

--- a/src/utilities/emojify.ts
+++ b/src/utilities/emojify.ts
@@ -9,10 +9,13 @@ export function emojifyHTML(content: string): string {
     const div = document.createElement('div');
     let html = content;
     let emojis: [Emoji] = JSON.parse(localStorage.getItem("emojis") as string);
-    emojis.forEach((emoji: Emoji) => {
-        let regexp = new RegExp(':' + emoji.name + ':', 'g');
-        html = html.replace(regexp, `<img src="${emoji.imageUrl}" class="emoji"/>`);
-    });
+    if (emojis !== null) {
+        emojis.forEach((emoji: Emoji) => {
+            let regexp = new RegExp(':' + emoji.name + ':', 'g');
+            html = html.replace(regexp, `<img src="${emoji.imageUrl}" class="emoji"/>`);
+        });
+    }
+    
     div.innerHTML = html;
     return div.innerHTML;
 }

--- a/src/utilities/emojify.ts
+++ b/src/utilities/emojify.ts
@@ -1,0 +1,18 @@
+import {Emoji} from '../types/Emojis';
+
+/**
+ * Takes a given string and inserts the correct emoji elements.
+ * @param content The HTML string to locate and replace emojis with
+ * @returns HTML string with emojis as `img` elements
+ */
+export function emojifyHTML(content: string): string {
+    const div = document.createElement('div');
+    let html = content;
+    let emojis: [Emoji] = JSON.parse(localStorage.getItem("emojis") as string);
+    emojis.forEach((emoji: Emoji) => {
+        let regexp = new RegExp(':' + emoji.name + ':', 'g');
+        html = html.replace(regexp, `<img src="${emoji.imageUrl}" class="emoji"/>`);
+    });
+    div.innerHTML = html;
+    return div.innerHTML;
+}


### PR DESCRIPTION
This PR makes the following changes:
- Custom emojis from the user's server can be used in a post by typing its shortcode or inserting it through the new emoji picker*.
- Posts and profile names display custom emoji.
- A new utility, `emojifyHTML`, will automatically replace emoji shortcodes with `img` elements.

> Note: the new emoji picker exists only in the `ComposeWindow` element. This will be updated to when I introduce a new base composer that can be applied anywhere to reduce code duplication.